### PR TITLE
fix: source .env in deploy script for prisma migrate

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -23,6 +23,11 @@ ssh ${SERVER} << 'REMOTE'
 set -euo pipefail
 cd /home/tessitura/app
 
+# Load environment variables for database access
+set -a
+source /home/tessitura/.env
+set +a
+
 # Install dependencies
 npm ci
 


### PR DESCRIPTION
## Summary
Deploy script fails at `prisma migrate deploy` because DATABASE_URL isn't set. The server stores it in `/home/tessitura/.env` (loaded by systemd's EnvironmentFile), but the deploy script runs as root via SSH without that env file loaded.

## Fix
Source `/home/tessitura/.env` before running npm/prisma commands in the deploy script.

## Verification
CI should pass, and deploy job should now complete successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)