### PR TITLE
fix: source .env after npm ci in deploy script

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -23,13 +23,13 @@ ssh ${SERVER} << 'REMOTE'
 set -euo pipefail
 cd /home/tessitura/app
 
-# Load environment variables for database access
+# Install dependencies (before sourcing .env so NODE_ENV=production doesn't skip devDeps)
+npm ci
+
+# Load environment variables for database access (after npm ci, before prisma)
 set -a
 source /home/tessitura/.env
 set +a
-
-# Install dependencies
-npm ci
 
 # Generate Prisma client
 npx prisma generate


### PR DESCRIPTION
## Summary
- PR #11 sourced `.env` before `npm ci`, but if `.env` contains `NODE_ENV=production`, npm ci skips devDependencies
- `dotenv` is a devDependency, so `prisma.config.ts` (which imports `dotenv/config`) fails to load
- Fix: move `source .env` to after `npm ci` but before prisma commands

## Evidence
- Deploy run [#23102885037](https://github.com/evilstickman/tessitura/actions/runs/23102885037) failed with: `Cannot find module 'dotenv/config'`

## Test plan
- [ ] CI passes
- [ ] Deploy job completes successfully
- [ ] Site is accessible at 159.223.198.58

🤖 Generated with [Claude Code](https://claude.com/claude-code)