### PR TITLE
feat: M1.3 Grid CRUD API — four endpoints with full MCV pattern

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "coverage/**",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-config-next": "16.1.6",
         "prisma": "^7.5.0",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.1.0"
       }
@@ -393,6 +394,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4138,6 +4581,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escalade": {
@@ -8183,6 +8668,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "seed": "npx tsx prisma/seed.ts"
   },
   "scripts": {
+    "postinstall": "prisma generate",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tessitura",
   "version": "0.1.0",
   "private": true,
+  "prisma": {
+    "seed": "npx tsx prisma/seed.ts"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -34,6 +37,7 @@
     "eslint-config-next": "16.1.6",
     "prisma": "^7.5.0",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.0"
   }

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "npx tsx prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/prisma/migrations/20260315050448_add_passage_label_to_practice_row/migration.sql
+++ b/prisma/migrations/20260315050448_add_passage_label_to_practice_row/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "practice_rows" ADD COLUMN     "passage_label" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model PracticeRow {
   songTitle      String?   @map("song_title")
   composer       String?
   part           String?
+  passageLabel   String?   @map("passage_label")
   startMeasure   Int       @map("start_measure")
   endMeasure     Int       @map("end_measure")
   targetTempo    Int       @map("target_tempo")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,26 @@
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../src/generated/prisma/client';
+
+async function main() {
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+  const prisma = new PrismaClient({ adapter });
+
+  const seedUser = await prisma.user.upsert({
+    where: { email: 'dev-placeholder@tessitura.local' },
+    update: {},
+    create: {
+      email: 'dev-placeholder@tessitura.local',
+      passwordHash: 'not-a-real-hash',
+      displayName: 'Dev User',
+      instruments: [],
+    },
+  });
+
+  console.log(`Seed user: ${seedUser.id} (${seedUser.email})`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/grids/[id]/route.ts
+++ b/src/app/api/grids/[id]/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { getGrid, deleteGrid } from '@/controllers/grid';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return getGrid(id);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return deleteGrid(id);
+}

--- a/src/app/api/grids/route.ts
+++ b/src/app/api/grids/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { createGrid, listGrids } from '@/controllers/grid';
+
+export async function POST(request: NextRequest) {
+  return createGrid(request);
+}
+
+export async function GET() {
+  return listGrids();
+}

--- a/src/controllers/grid.ts
+++ b/src/controllers/grid.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUserId } from '@/lib/auth';
+import {
+  createGrid as createGridModel,
+  listGrids as listGridsModel,
+  getGridById,
+  deleteGrid as deleteGridModel,
+  ValidationError,
+} from '@/models/grid';
+import { formatGrid, formatGridDetail, formatGridList } from '@/views/grid';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorResponse(message: string, code: string, status: number) {
+  return NextResponse.json({ error: { message, code } }, { status });
+}
+
+export async function createGrid(request: NextRequest) {
+  try {
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body.name !== 'string') {
+      return errorResponse('Grid name is required', 'VALIDATION_ERROR', 400);
+    }
+
+    const grid = await createGridModel(userId, {
+      name: body.name,
+      notes: body.notes ?? null,
+    });
+
+    return NextResponse.json(formatGrid(grid), { status: 201 });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function listGrids() {
+  try {
+    const userId = await getCurrentUserId();
+    const grids = await listGridsModel(userId);
+    return NextResponse.json(formatGridList(grids));
+  } catch {
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function getGrid(gridId: string) {
+  try {
+    if (!UUID_REGEX.test(gridId)) {
+      return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const userId = await getCurrentUserId();
+    const grid = await getGridById(gridId, userId);
+
+    if (!grid) {
+      return errorResponse('Grid not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(formatGridDetail(grid));
+  } catch {
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function deleteGrid(gridId: string) {
+  try {
+    if (!UUID_REGEX.test(gridId)) {
+      return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const userId = await getCurrentUserId();
+    const deleted = await deleteGridModel(gridId, userId);
+
+    if (!deleted) {
+      return errorResponse('Grid not found', 'NOT_FOUND', 404);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/controllers/grid.ts
+++ b/src/controllers/grid.ts
@@ -24,6 +24,10 @@ export async function createGrid(request: NextRequest) {
       return errorResponse('Grid name is required', 'VALIDATION_ERROR', 400);
     }
 
+    if (body.notes != null && typeof body.notes !== 'string') {
+      return errorResponse('Notes must be a string', 'VALIDATION_ERROR', 400);
+    }
+
     const grid = await createGridModel(userId, {
       name: body.name,
       notes: body.notes ?? null,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,14 @@
 let seedUserId: string | null = null;
 
 /**
+ * Resets the cached seed user ID. Used by test setup to prevent stale cache
+ * after database cleanup between tests.
+ */
+export function resetAuthCache(): void {
+  seedUserId = null;
+}
+
+/**
  * Returns the current user's ID.
  * Before M1.8 (auth), this returns the dev seed user.
  */

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,28 @@
+// TODO(M1.8): Replace with real session auth.
+// This is a placeholder that returns the dev seed user's ID.
+// Every controller must call this function — no hardcoded user IDs elsewhere.
+
+let seedUserId: string | null = null;
+
+/**
+ * Returns the current user's ID.
+ * Before M1.8 (auth), this returns the dev seed user.
+ */
+export async function getCurrentUserId(): Promise<string> {
+  if (seedUserId) return seedUserId;
+
+  // Lazy-load to avoid circular imports with db.ts
+  const { prisma } = await import('@/lib/db');
+  const user = await prisma.user.findFirst({
+    where: { email: 'dev-placeholder@tessitura.local' },
+  });
+
+  if (!user) {
+    throw new Error(
+      'Dev seed user not found. Run `npx prisma db seed` to create it.',
+    );
+  }
+
+  seedUserId = user.id;
+  return seedUserId;
+}

--- a/src/models/grid.ts
+++ b/src/models/grid.ts
@@ -140,8 +140,8 @@ export async function deleteGrid(gridId: string, userId: string): Promise<boolea
       data: { deletedAt: now },
     });
 
-    await tx.practiceGrid.update({
-      where: { id: gridId },
+    await tx.practiceGrid.updateMany({
+      where: { id: gridId, deletedAt: null },
       data: { deletedAt: now },
     });
   });

--- a/src/models/grid.ts
+++ b/src/models/grid.ts
@@ -1,0 +1,150 @@
+import { prisma } from '@/lib/db';
+
+export interface GridInput {
+  name: string;
+  notes?: string | null;
+}
+
+export interface ValidatedGridInput {
+  name: string;
+  notes: string | null;
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+/**
+ * Validates and normalizes grid input.
+ * Pure function — no database access.
+ */
+export function validateGridInput(input: GridInput): ValidatedGridInput {
+  const name = (input.name ?? '').trim();
+
+  if (name.length === 0) {
+    throw new ValidationError('Grid name is required');
+  }
+
+  if (name.length > 200) {
+    throw new ValidationError('Grid name must be 200 characters or less');
+  }
+
+  const trimmedNotes = input.notes != null ? input.notes.trim() : null;
+  // Whitespace-only notes normalize to null (not empty string)
+  const notes = trimmedNotes === '' ? null : trimmedNotes;
+
+  return { name, notes };
+}
+
+/**
+ * Creates a new practice grid.
+ */
+export async function createGrid(userId: string, input: GridInput) {
+  const validated = validateGridInput(input);
+
+  return prisma.practiceGrid.create({
+    data: {
+      userId,
+      name: validated.name,
+      notes: validated.notes,
+      fadeEnabled: true,
+    },
+  });
+}
+
+/**
+ * Lists all grids for a user, sorted by updatedAt descending.
+ */
+export async function listGrids(userId: string) {
+  return prisma.practiceGrid.findMany({
+    where: { userId },
+    orderBy: { updatedAt: 'desc' },
+  });
+}
+
+/**
+ * Gets a single grid with full nested data. Returns null if not found or not owned.
+ */
+export async function getGridById(gridId: string, userId: string) {
+  const grid = await prisma.practiceGrid.findUnique({
+    where: { id: gridId },
+    include: {
+      practiceRows: {
+        orderBy: { sortOrder: 'asc' },
+        include: {
+          practiceCells: {
+            orderBy: { stepNumber: 'asc' },
+            include: {
+              completions: {
+                orderBy: { completionDate: 'asc' },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  // Ownership check — return null (controller maps to 404)
+  if (!grid || grid.userId !== userId) {
+    return null;
+  }
+
+  return grid;
+}
+
+/**
+ * Soft-deletes a grid and all children in a single transaction.
+ * Returns true if deleted, false if not found/not owned.
+ */
+export async function deleteGrid(gridId: string, userId: string): Promise<boolean> {
+  const grid = await prisma.practiceGrid.findUnique({
+    where: { id: gridId },
+  });
+
+  if (!grid || grid.userId !== userId) {
+    return false;
+  }
+
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    // Cascade: completions → cells → rows → grid
+    await tx.practiceCellCompletion.updateMany({
+      where: {
+        practiceCell: {
+          practiceRow: {
+            practiceGridId: gridId,
+          },
+        },
+        deletedAt: null,
+      },
+      data: { deletedAt: now },
+    });
+
+    await tx.practiceCell.updateMany({
+      where: {
+        practiceRow: {
+          practiceGridId: gridId,
+        },
+        deletedAt: null,
+      },
+      data: { deletedAt: now },
+    });
+
+    await tx.practiceRow.updateMany({
+      where: { practiceGridId: gridId, deletedAt: null },
+      data: { deletedAt: now },
+    });
+
+    await tx.practiceGrid.update({
+      where: { id: gridId },
+      data: { deletedAt: now },
+    });
+  });
+
+  return true;
+}

--- a/src/views/grid.ts
+++ b/src/views/grid.ts
@@ -1,0 +1,115 @@
+interface GridRow {
+  id: string;
+  practiceGridId: string;
+  sortOrder: number;
+  songTitle: string | null;
+  composer: string | null;
+  part: string | null;
+  passageLabel: string | null;
+  startMeasure: number;
+  endMeasure: number;
+  targetTempo: number;
+  steps: number;
+  priority: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  practiceCells: GridCell[];
+}
+
+interface GridCell {
+  id: string;
+  practiceRowId: string;
+  stepNumber: number;
+  targetTempoPercentage: number;
+  freshnessIntervalDays: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  completions: GridCompletion[];
+}
+
+interface GridCompletion {
+  id: string;
+  practiceCellId: string;
+  completionDate: Date;
+  createdAt: Date;
+  deletedAt: Date | null;
+}
+
+interface GridRecord {
+  id: string;
+  userId: string;
+  name: string;
+  notes: string | null;
+  fadeEnabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+interface GridDetailRecord extends GridRecord {
+  practiceRows: GridRow[];
+}
+
+function formatCompletion(completion: GridCompletion) {
+  return {
+    id: completion.id,
+    completionDate: completion.completionDate.toISOString(),
+    createdAt: completion.createdAt.toISOString(),
+  };
+}
+
+function formatCell(cell: GridCell, rowTargetTempo: number) {
+  return {
+    id: cell.id,
+    stepNumber: cell.stepNumber,
+    targetTempoPercentage: cell.targetTempoPercentage,
+    targetTempoBpm: Math.round(cell.targetTempoPercentage * rowTargetTempo),
+    freshnessIntervalDays: cell.freshnessIntervalDays,
+    createdAt: cell.createdAt.toISOString(),
+    updatedAt: cell.updatedAt.toISOString(),
+    completions: cell.completions.map(formatCompletion),
+  };
+}
+
+function formatRow(row: GridRow) {
+  return {
+    id: row.id,
+    sortOrder: row.sortOrder,
+    songTitle: row.songTitle,
+    composer: row.composer,
+    part: row.part,
+    passageLabel: row.passageLabel,
+    startMeasure: row.startMeasure,
+    endMeasure: row.endMeasure,
+    targetTempo: row.targetTempo,
+    steps: row.steps,
+    priority: row.priority,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    cells: row.practiceCells.map((cell) => formatCell(cell, row.targetTempo)),
+  };
+}
+
+export function formatGrid(grid: GridRecord) {
+  return {
+    id: grid.id,
+    name: grid.name,
+    notes: grid.notes,
+    fadeEnabled: grid.fadeEnabled,
+    createdAt: grid.createdAt.toISOString(),
+    updatedAt: grid.updatedAt.toISOString(),
+  };
+}
+
+export function formatGridDetail(grid: GridDetailRecord) {
+  return {
+    ...formatGrid(grid),
+    rows: grid.practiceRows.map(formatRow),
+  };
+}
+
+export function formatGridList(grids: GridRecord[]) {
+  return grids.map(formatGrid);
+}

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getTestPrisma } from '../../helpers/db';
+import {
+  createGrid,
+  listGrids,
+  getGrid,
+  deleteGrid,
+} from '@/controllers/grid';
+
+const prisma = getTestPrisma();
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/grids', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function createSeedUser() {
+  return prisma.user.upsert({
+    where: { email: 'dev-placeholder@tessitura.local' },
+    update: {},
+    create: {
+      email: 'dev-placeholder@tessitura.local',
+      passwordHash: 'not-a-real-hash',
+      displayName: 'Dev User',
+      instruments: [],
+    },
+  });
+}
+
+async function createOtherUser() {
+  return prisma.user.create({
+    data: {
+      email: `other-${Date.now()}@example.com`,
+      passwordHash: 'hash',
+      displayName: 'Other User',
+      instruments: [],
+    },
+  });
+}
+
+// ─── Task 9: Create Grid (tests 18–26) ────────────────────────────────────────
+
+describe('Grid API — Create', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  // Test 18
+  it('POST with valid name returns 201 with correct userId and defaults', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+
+    const res = await createGrid(makeRequest({ name: 'My Grid' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.name).toBe('My Grid');
+    expect(body.fadeEnabled).toBe(true);
+
+    // Verify userId at the database level (view strips it from response)
+    const created = await prisma.practiceGrid.findFirst({ where: { name: 'My Grid' } });
+    expect(created!.userId).toBe(seedUser.id);
+  });
+
+  // Test 19
+  it('POST with name and notes returns 201', async () => {
+    const res = await createGrid(makeRequest({ name: 'Grid', notes: 'My notes' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.name).toBe('Grid');
+    expect(body.notes).toBe('My notes');
+  });
+
+  // Test 20
+  it('POST with empty body returns 400 with error shape', async () => {
+    const req = new NextRequest('http://localhost:3000/api/grids', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const res = await createGrid(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+    expect(body.error.message).toBeDefined();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  // Test 21
+  it('POST with empty string name returns 400', async () => {
+    const res = await createGrid(makeRequest({ name: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  // Test 22
+  it('POST with whitespace-only name returns 400', async () => {
+    const res = await createGrid(makeRequest({ name: '   ' }));
+    expect(res.status).toBe(400);
+  });
+
+  // Test 23
+  it('POST with name over 200 chars returns 400', async () => {
+    const res = await createGrid(makeRequest({ name: 'a'.repeat(201) }));
+    expect(res.status).toBe(400);
+  });
+
+  // Test 24
+  it('POST returns grid with UUID id and timestamps', async () => {
+    const res = await createGrid(makeRequest({ name: 'UUID Test' }));
+    const body = await res.json();
+    expect(body.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(body.createdAt).toBeDefined();
+    expect(body.updatedAt).toBeDefined();
+  });
+
+  // Test 25
+  it('POST with HTML in name stores and returns it unchanged', async () => {
+    const htmlName = "<script>alert('xss')</script>";
+    const res = await createGrid(makeRequest({ name: htmlName }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.name).toBe(htmlName);
+  });
+
+  // Test 26
+  it('POST with HTML in notes stores and returns it unchanged', async () => {
+    const res = await createGrid(
+      makeRequest({ name: 'Grid', notes: '<b>bold</b>' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.notes).toBe('<b>bold</b>');
+  });
+});
+
+// ─── Task 10: List Grids (tests 27–31) ───────────────────────────────────────
+
+describe('Grid API — List', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  // Test 27
+  it('GET returns 200 with empty array when user has no grids', async () => {
+    const res = await listGrids();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  // Test 28
+  it('GET returns only grids belonging to the current user', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const otherUser = await createOtherUser();
+
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'My Grid' },
+    });
+    await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Other Grid' },
+    });
+
+    const res = await listGrids();
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('My Grid');
+  });
+
+  // Test 29
+  it('GET excludes soft-deleted grids', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Active Grid' },
+    });
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Deleted Grid', deletedAt: new Date() },
+    });
+
+    const res = await listGrids();
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('Active Grid');
+  });
+
+  // Test 30
+  it('GET returns grids sorted by updatedAt descending', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+
+    const grid1 = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'First' },
+    });
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Second' },
+    });
+    // Update first grid to make it most recent
+    await prisma.practiceGrid.update({
+      where: { id: grid1.id },
+      data: { notes: 'updated' },
+    });
+
+    const res = await listGrids();
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].name).toBe('First');
+    expect(body[1].name).toBe('Second');
+  });
+
+  // Test 31
+  it('GET response has no deletedAt or userId', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Format Test' },
+    });
+
+    const res = await listGrids();
+    const body = await res.json();
+    expect(body[0]).not.toHaveProperty('deletedAt');
+    expect(body[0]).not.toHaveProperty('userId');
+  });
+});
+
+// ─── Task 11: Get Grid Detail (tests 32–39) ───────────────────────────────────
+
+describe('Grid API — Detail', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  // Test 32
+  it('GET /grids/[id] returns full nested structure', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Detail Grid' },
+    });
+    const row = await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 8,
+        targetTempo: 120,
+        steps: 2,
+      },
+    });
+    const cell = await prisma.practiceCell.create({
+      data: {
+        practiceRowId: row.id,
+        stepNumber: 0,
+        targetTempoPercentage: 0.4,
+      },
+    });
+    await prisma.practiceCellCompletion.create({
+      data: {
+        practiceCellId: cell.id,
+        completionDate: new Date('2026-03-15'),
+      },
+    });
+
+    const res = await getGrid(grid.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].cells).toHaveLength(1);
+    expect(body.rows[0].cells[0].completions).toHaveLength(1);
+  });
+
+  // Test 33
+  it('GET /grids/[id] returns rows sorted by sortOrder ascending', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Sort Grid' },
+    });
+    await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 2,
+        startMeasure: 9,
+        endMeasure: 16,
+        targetTempo: 100,
+        steps: 1,
+      },
+    });
+    await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 8,
+        targetTempo: 120,
+        steps: 1,
+      },
+    });
+
+    const res = await getGrid(grid.id);
+    const body = await res.json();
+    expect(body.rows[0].sortOrder).toBe(0);
+    expect(body.rows[1].sortOrder).toBe(2);
+  });
+
+  // Test 34
+  it('GET /grids/[id] returns cells sorted by stepNumber ascending', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Cell Sort' },
+    });
+    const row = await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 8,
+        targetTempo: 120,
+        steps: 3,
+      },
+    });
+    // Create cells out of order
+    await prisma.practiceCell.create({
+      data: { practiceRowId: row.id, stepNumber: 2, targetTempoPercentage: 1.0 },
+    });
+    await prisma.practiceCell.create({
+      data: { practiceRowId: row.id, stepNumber: 0, targetTempoPercentage: 0.4 },
+    });
+
+    const res = await getGrid(grid.id);
+    const body = await res.json();
+    expect(body.rows[0].cells[0].stepNumber).toBe(0);
+    expect(body.rows[0].cells[1].stepNumber).toBe(2);
+  });
+
+  // Test 35
+  it('GET /grids/[id] returns completions sorted by completionDate ascending', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Comp Sort' },
+    });
+    const row = await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 4,
+        targetTempo: 100,
+        steps: 1,
+      },
+    });
+    const cell = await prisma.practiceCell.create({
+      data: { practiceRowId: row.id, stepNumber: 0, targetTempoPercentage: 0.4 },
+    });
+    // Create completions out of order
+    await prisma.practiceCellCompletion.create({
+      data: { practiceCellId: cell.id, completionDate: new Date('2026-03-16') },
+    });
+    await prisma.practiceCellCompletion.create({
+      data: { practiceCellId: cell.id, completionDate: new Date('2026-03-14') },
+    });
+
+    const res = await getGrid(grid.id);
+    const body = await res.json();
+    const dates = body.rows[0].cells[0].completions.map(
+      (c: { completionDate: string }) => c.completionDate,
+    );
+    expect(new Date(dates[0]).getTime()).toBeLessThan(new Date(dates[1]).getTime());
+  });
+
+  // Test 36
+  it('GET /grids/[id] returns 404 for non-existent ID', async () => {
+    const res = await getGrid('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+
+  // Test 37
+  it('GET /grids/[id] returns 404 for grid owned by different user', async () => {
+    const otherUser = await createOtherUser();
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Not Mine' },
+    });
+
+    const res = await getGrid(grid.id);
+    expect(res.status).toBe(404);
+  });
+
+  // Test 38
+  it('GET /grids/[id] returns 404 for soft-deleted grid', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Deleted', deletedAt: new Date() },
+    });
+
+    const res = await getGrid(grid.id);
+    expect(res.status).toBe(404);
+  });
+
+  // Test 39
+  it('GET /grids/[id] returns 400 for malformed UUID', async () => {
+    const res = await getGrid('not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Task 12: Delete Grid (tests 40–46) ──────────────────────────────────────
+
+describe('Grid API — Delete', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  // Test 40
+  it('DELETE returns 204 and sets deletedAt', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'To Delete' },
+    });
+
+    const res = await deleteGrid(grid.id);
+    expect(res.status).toBe(204);
+
+    // Verify via raw query (raw client sees deleted records)
+    const deleted = await prisma.practiceGrid.findUnique({
+      where: { id: grid.id },
+    });
+    expect(deleted!.deletedAt).not.toBeNull();
+  });
+
+  // Test 41
+  it('DELETE cascades to child rows, cells, and completions', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Cascade Grid' },
+    });
+    const row = await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 8,
+        targetTempo: 120,
+        steps: 1,
+      },
+    });
+    const cell = await prisma.practiceCell.create({
+      data: { practiceRowId: row.id, stepNumber: 0, targetTempoPercentage: 0.4 },
+    });
+    const completion = await prisma.practiceCellCompletion.create({
+      data: { practiceCellId: cell.id, completionDate: new Date('2026-03-15') },
+    });
+
+    await deleteGrid(grid.id);
+
+    // All children should have deletedAt set (raw client can see them)
+    const deletedRow = await prisma.practiceRow.findUnique({ where: { id: row.id } });
+    const deletedCell = await prisma.practiceCell.findUnique({ where: { id: cell.id } });
+    const deletedCompletion = await prisma.practiceCellCompletion.findUnique({
+      where: { id: completion.id },
+    });
+
+    expect(deletedRow!.deletedAt).not.toBeNull();
+    expect(deletedCell!.deletedAt).not.toBeNull();
+    expect(deletedCompletion!.deletedAt).not.toBeNull();
+  });
+
+  // Test 42
+  it('DELETE returns 404 for non-existent grid', async () => {
+    const res = await deleteGrid('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+
+  // Test 43
+  it('DELETE returns 404 for grid owned by different user', async () => {
+    const otherUser = await createOtherUser();
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Not Mine' },
+    });
+
+    const res = await deleteGrid(grid.id);
+    expect(res.status).toBe(404);
+  });
+
+  // Test 44
+  it('DELETE returns 404 for already-deleted grid', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Already Gone', deletedAt: new Date() },
+    });
+
+    const res = await deleteGrid(grid.id);
+    expect(res.status).toBe(404);
+  });
+
+  // Test 45
+  it('DELETE returns 400 for malformed UUID', async () => {
+    const res = await deleteGrid('not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+
+  // Test 46
+  it('deleted grid no longer appears in list', async () => {
+    const seedUser = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Will Vanish' },
+    });
+
+    // Verify it appears first
+    const beforeRes = await listGrids();
+    const beforeBody = await beforeRes.json();
+    expect(beforeBody).toHaveLength(1);
+
+    // Delete it
+    await deleteGrid(grid.id);
+
+    // Verify it's gone
+    const afterRes = await listGrids();
+    const afterBody = await afterRes.json();
+    expect(afterBody).toHaveLength(0);
+  });
+});

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -62,8 +62,8 @@ describe('Grid API — Create', () => {
     expect(body.fadeEnabled).toBe(true);
 
     // Verify userId at the database level (view strips it from response)
-    const created = await prisma.practiceGrid.findFirst({ where: { name: 'My Grid' } });
-    expect(created!.userId).toBe(seedUser.id);
+    const created = await prisma.practiceGrid.findUniqueOrThrow({ where: { id: body.id } });
+    expect(created.userId).toBe(seedUser.id);
   });
 
   // Test 19
@@ -94,18 +94,24 @@ describe('Grid API — Create', () => {
   it('POST with empty string name returns 400', async () => {
     const res = await createGrid(makeRequest({ name: '' }));
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // Test 22
   it('POST with whitespace-only name returns 400', async () => {
     const res = await createGrid(makeRequest({ name: '   ' }));
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // Test 23
   it('POST with name over 200 chars returns 400', async () => {
     const res = await createGrid(makeRequest({ name: 'a'.repeat(201) }));
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // Test 24
@@ -199,23 +205,29 @@ describe('Grid API — List', () => {
       where: { email: 'dev-placeholder@tessitura.local' },
     });
 
-    const grid1 = await prisma.practiceGrid.create({
-      data: { userId: seedUser.id, name: 'First' },
+    // Create 3 grids with explicit timestamps to avoid timing dependencies
+    const now = new Date();
+    await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'First', updatedAt: new Date(now.getTime() - 3000) },
+    });
+    const grid2 = await prisma.practiceGrid.create({
+      data: { userId: seedUser.id, name: 'Second', updatedAt: new Date(now.getTime() - 2000) },
     });
     await prisma.practiceGrid.create({
-      data: { userId: seedUser.id, name: 'Second' },
+      data: { userId: seedUser.id, name: 'Third', updatedAt: new Date(now.getTime() - 1000) },
     });
-    // Update first grid to make it most recent
+    // Update middle grid to make it most recent
     await prisma.practiceGrid.update({
-      where: { id: grid1.id },
-      data: { notes: 'updated' },
+      where: { id: grid2.id },
+      data: { notes: 'updated', updatedAt: now },
     });
 
     const res = await listGrids();
     const body = await res.json();
-    expect(body).toHaveLength(2);
-    expect(body[0].name).toBe('First');
-    expect(body[1].name).toBe('Second');
+    expect(body).toHaveLength(3);
+    expect(body[0].name).toBe('Second'); // most recently updated
+    expect(body[1].name).toBe('Third');  // created last, never updated
+    expect(body[2].name).toBe('First');  // created first, never updated
   });
 
   // Test 31

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -42,6 +42,39 @@ async function createOtherUser() {
   });
 }
 
+// ─── Error handling ──────────────────────────────────────────────────────────
+
+describe('Grid API — Error handling', () => {
+  // No seed user created — exercises the 500 catch blocks
+  it('returns 500 when auth fails on createGrid', async () => {
+    const res = await createGrid(makeRequest({ name: 'Grid' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('returns 500 when auth fails on listGrids', async () => {
+    const res = await listGrids();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('returns 500 when auth fails on getGrid', async () => {
+    const res = await getGrid('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('returns 500 when auth fails on deleteGrid', async () => {
+    const res = await deleteGrid('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
 // ─── Task 9: Create Grid (tests 18–26) ────────────────────────────────────────
 
 describe('Grid API — Create', () => {
@@ -132,6 +165,14 @@ describe('Grid API — Create', () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.name).toBe(htmlName);
+  });
+
+  // Test 25a
+  it('POST with non-string notes returns 400', async () => {
+    const res = await createGrid(makeRequest({ name: 'Grid', notes: 123 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // Test 26

--- a/tests/integration/lib/soft-delete-extensions.test.ts
+++ b/tests/integration/lib/soft-delete-extensions.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTestPrisma } from '../../helpers/db';
+import { prisma } from '@/lib/db';
+
+const rawPrisma = getTestPrisma();
+
+async function createTestUser() {
+  return rawPrisma.user.create({
+    data: {
+      email: 'soft-delete-test@example.com',
+      passwordHash: 'hash',
+      displayName: 'Test User',
+      instruments: [],
+    },
+  });
+}
+
+describe('Soft-delete Prisma extension', () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    const user = await createTestUser();
+    userId = user.id;
+  });
+
+  it('count excludes soft-deleted records', async () => {
+    await rawPrisma.practiceGrid.create({
+      data: { userId, name: 'Active' },
+    });
+    await rawPrisma.practiceGrid.create({
+      data: { userId, name: 'Deleted', deletedAt: new Date() },
+    });
+
+    const count = await prisma.practiceGrid.count({ where: { userId } });
+    expect(count).toBe(1);
+  });
+
+  it('delete converts to soft-delete', async () => {
+    const grid = await rawPrisma.practiceGrid.create({
+      data: { userId, name: 'To Soft Delete' },
+    });
+
+    await prisma.practiceGrid.delete({ where: { id: grid.id } });
+
+    // Raw client should see the record with deletedAt set
+    const deleted = await rawPrisma.practiceGrid.findUnique({ where: { id: grid.id } });
+    expect(deleted).not.toBeNull();
+    expect(deleted!.deletedAt).not.toBeNull();
+  });
+
+  it('deleteMany converts to soft-delete', async () => {
+    await rawPrisma.practiceGrid.create({
+      data: { userId, name: 'Batch 1' },
+    });
+    await rawPrisma.practiceGrid.create({
+      data: { userId, name: 'Batch 2' },
+    });
+
+    await prisma.practiceGrid.deleteMany({ where: { userId } });
+
+    // Raw client should see records with deletedAt set
+    const records = await rawPrisma.practiceGrid.findMany({ where: { userId } });
+    expect(records).toHaveLength(2);
+    expect(records.every((r) => r.deletedAt !== null)).toBe(true);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,9 @@
 import { afterAll, afterEach } from 'vitest';
 import { cleanDatabase, disconnectTestDb, hasTestPrisma } from './helpers/db';
+import { resetAuthCache } from '@/lib/auth';
 
 afterEach(async () => {
+  resetAuthCache();
   if (hasTestPrisma()) {
     await cleanDatabase();
   }

--- a/tests/unit/lib/auth.test.ts
+++ b/tests/unit/lib/auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getCurrentUserId, resetAuthCache } from '@/lib/auth';
+
+describe('getCurrentUserId', () => {
+  afterEach(() => {
+    resetAuthCache();
+  });
+
+  it('throws when seed user does not exist', async () => {
+    // The test database is cleaned between tests by setup.ts,
+    // so if we call getCurrentUserId without creating the seed user, it should throw.
+    // But the import of @/lib/db initializes the Prisma client which tries to connect.
+    // We're in a unit test context — the test DB is available but empty after cleanup.
+    await expect(getCurrentUserId()).rejects.toThrow('Dev seed user not found');
+  });
+});

--- a/tests/unit/lib/env.test.ts
+++ b/tests/unit/lib/env.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateEnv } from '@/lib/env';
+
+describe('validateEnv', () => {
+  const originalEnv = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.DATABASE_URL = originalEnv;
+    }
+  });
+
+  it('returns env vars when all required vars are present', () => {
+    process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+    const result = validateEnv();
+    expect(result.DATABASE_URL).toBe('postgresql://localhost:5432/test');
+  });
+
+  it('throws when required vars are missing', () => {
+    const saved = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      expect(() => validateEnv()).toThrow('Missing required environment variables');
+    } finally {
+      process.env.DATABASE_URL = saved;
+    }
+  });
+});

--- a/tests/unit/models/grid.test.ts
+++ b/tests/unit/models/grid.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { validateGridInput } from '@/models/grid';
+
+describe('Grid model — validateGridInput', () => {
+  // Test 1
+  it('accepts a valid name and returns it trimmed', () => {
+    const result = validateGridInput({ name: 'My Practice Grid' });
+    expect(result.name).toBe('My Practice Grid');
+  });
+
+  // Test 2
+  it('rejects an empty string name', () => {
+    expect(() => validateGridInput({ name: '' })).toThrow();
+  });
+
+  // Test 3
+  it('rejects a whitespace-only name', () => {
+    expect(() => validateGridInput({ name: '   ' })).toThrow();
+  });
+
+  // Test 4
+  it('rejects a name over 200 characters', () => {
+    const longName = 'a'.repeat(201);
+    expect(() => validateGridInput({ name: longName })).toThrow();
+  });
+
+  // Test 5
+  it('accepts a name at exactly 200 characters', () => {
+    const name = 'a'.repeat(200);
+    const result = validateGridInput({ name });
+    expect(result.name).toBe(name);
+  });
+
+  // Test 6
+  it('trims leading and trailing whitespace from name', () => {
+    const result = validateGridInput({ name: '  My Grid  ' });
+    expect(result.name).toBe('My Grid');
+  });
+
+  // Test 7
+  it('accepts a name with special characters', () => {
+    const name = "Grieg's Holberg Suite — Mvt. III";
+    const result = validateGridInput({ name });
+    expect(result.name).toBe(name);
+  });
+
+  // Test 8
+  it('accepts null notes and stores as null', () => {
+    const result = validateGridInput({ name: 'Grid' });
+    expect(result.notes).toBeNull();
+  });
+
+  // Test 9
+  it('accepts non-empty notes as-is', () => {
+    const result = validateGridInput({ name: 'Grid', notes: 'Some notes' });
+    expect(result.notes).toBe('Some notes');
+  });
+
+  // Test 10
+  it('trims notes whitespace', () => {
+    const result = validateGridInput({ name: 'Grid', notes: '  padded  ' });
+    expect(result.notes).toBe('padded');
+  });
+
+  // Test 11
+  it('accepts notes with 10,000+ characters', () => {
+    const longNotes = 'x'.repeat(10_001);
+    const result = validateGridInput({ name: 'Grid', notes: longNotes });
+    expect(result.notes).toBe(longNotes);
+  });
+});

--- a/tests/unit/models/grid.test.ts
+++ b/tests/unit/models/grid.test.ts
@@ -62,6 +62,12 @@ describe('Grid model — validateGridInput', () => {
     expect(result.notes).toBe('padded');
   });
 
+  // Test 10a
+  it('normalizes whitespace-only notes to null', () => {
+    const result = validateGridInput({ name: 'Grid', notes: '   ' });
+    expect(result.notes).toBeNull();
+  });
+
   // Test 11
   it('accepts notes with 10,000+ characters', () => {
     const longNotes = 'x'.repeat(10_001);

--- a/tests/unit/views/grid.test.ts
+++ b/tests/unit/views/grid.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { formatGrid, formatGridDetail, formatGridList } from '@/views/grid';
+
+const mockGrid = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  userId: 'user-id-should-be-stripped',
+  name: 'Test Grid',
+  notes: 'Some notes',
+  fadeEnabled: true,
+  createdAt: new Date('2026-03-15T10:00:00Z'),
+  updatedAt: new Date('2026-03-15T12:00:00Z'),
+  deletedAt: null,
+};
+
+const mockGridWithRows = {
+  ...mockGrid,
+  practiceRows: [
+    {
+      id: 'row-1',
+      practiceGridId: 'grid-id',
+      sortOrder: 0,
+      songTitle: 'Test Song',
+      composer: 'Bach',
+      part: '1st Cornet',
+      passageLabel: 'Letter A to B',
+      startMeasure: 1,
+      endMeasure: 8,
+      targetTempo: 120,
+      steps: 3,
+      priority: 'HIGH' as const,
+      createdAt: new Date('2026-03-15T10:00:00Z'),
+      updatedAt: new Date('2026-03-15T10:00:00Z'),
+      deletedAt: null,
+      practiceCells: [
+        {
+          id: 'cell-1',
+          practiceRowId: 'row-1',
+          stepNumber: 0,
+          targetTempoPercentage: 0.4,
+          freshnessIntervalDays: 1,
+          createdAt: new Date('2026-03-15T10:00:00Z'),
+          updatedAt: new Date('2026-03-15T10:00:00Z'),
+          deletedAt: null,
+          completions: [
+            {
+              id: 'comp-1',
+              practiceCellId: 'cell-1',
+              completionDate: new Date('2026-03-15'),
+              createdAt: new Date('2026-03-15T10:00:00Z'),
+              deletedAt: null,
+            },
+          ],
+        },
+        {
+          id: 'cell-2',
+          practiceRowId: 'row-1',
+          stepNumber: 1,
+          targetTempoPercentage: 0.7333333,
+          freshnessIntervalDays: 1,
+          createdAt: new Date('2026-03-15T10:00:00Z'),
+          updatedAt: new Date('2026-03-15T10:00:00Z'),
+          deletedAt: null,
+          completions: [],
+        },
+      ],
+    },
+  ],
+};
+
+describe('Grid view — formatGrid', () => {
+  // Test 12
+  it('includes public fields and omits userId and deletedAt', () => {
+    const result = formatGrid(mockGrid);
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('name');
+    expect(result).toHaveProperty('notes');
+    expect(result).toHaveProperty('fadeEnabled');
+    expect(result).toHaveProperty('createdAt');
+    expect(result).toHaveProperty('updatedAt');
+    expect(result).not.toHaveProperty('userId');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+});
+
+describe('Grid view — formatGridDetail', () => {
+  // Test 13
+  it('includes nested rows, cells, and completions with correct filtering', () => {
+    const result = formatGridDetail(mockGridWithRows);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].cells).toHaveLength(2);
+    expect(result.rows[0].cells[0].completions).toHaveLength(1);
+    // Row should not expose practiceGridId or deletedAt
+    expect(result.rows[0]).not.toHaveProperty('practiceGridId');
+    expect(result.rows[0]).not.toHaveProperty('deletedAt');
+    // Cell should not expose practiceRowId or deletedAt
+    expect(result.rows[0].cells[0]).not.toHaveProperty('practiceRowId');
+    expect(result.rows[0].cells[0]).not.toHaveProperty('deletedAt');
+    // Completion should not expose practiceCellId or deletedAt
+    expect(result.rows[0].cells[0].completions[0]).not.toHaveProperty('practiceCellId');
+    expect(result.rows[0].cells[0].completions[0]).not.toHaveProperty('deletedAt');
+  });
+
+  // Test 14
+  it('returns empty rows array when grid has no rows', () => {
+    const emptyGrid = { ...mockGrid, practiceRows: [] };
+    const result = formatGridDetail(emptyGrid);
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe('Grid view — timestamps', () => {
+  // Test 15
+  it('formats timestamps as ISO 8601 strings', () => {
+    const result = formatGrid(mockGrid);
+    expect(result.createdAt).toBe('2026-03-15T10:00:00.000Z');
+    expect(result.updatedAt).toBe('2026-03-15T12:00:00.000Z');
+  });
+});
+
+describe('Grid view — formatGridList', () => {
+  // Test 16
+  it('returns array of formatted grids', () => {
+    const result = formatGridList([mockGrid, { ...mockGrid, id: 'other-id' }]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).not.toHaveProperty('userId');
+    expect(result[1]).not.toHaveProperty('userId');
+  });
+});
+
+describe('Grid view — tempo rounding', () => {
+  // Test 17
+  it('rounds cell tempo values to integers', () => {
+    const result = formatGridDetail(mockGridWithRows);
+    // 0.7333333 * 120 = 88.0 (but could be 87.99999...)
+    // The view should round to the nearest integer
+    const cell = result.rows[0].cells[1];
+    expect(Number.isInteger(cell.targetTempoBpm)).toBe(true);
+    expect(cell.targetTempoBpm).toBe(88);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         statements: 95,
       },
       include: ['src/**/*.ts', 'src/**/*.tsx'],
-      exclude: ['src/app/**', 'src/components/**'],
+      exclude: ['src/app/**', 'src/components/**', 'src/generated/**'],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Implements M1.3: Grid CRUD API — the first four REST endpoints for Tessitura, establishing the MCV (Model-Controller-View) patterns that all future endpoints will follow.

- **POST /api/grids** — Create a practice grid (201/400)
- **GET /api/grids** — List user's grids, sorted by updatedAt desc (200)
- **GET /api/grids/[id]** — Grid detail with full nested structure: rows → cells → completions (200/400/404)
- **DELETE /api/grids/[id]** — Soft delete with cascade to all children in a single ACID transaction (204/400/404)

Also includes: schema migration adding `passageLabel` to PracticeRow, auth placeholder for pre-M1.8 development, dev seed script, and `postinstall` hook for `prisma generate`.

**Design doc:** `docs/plans/2026-03-15-m1.3-grid-crud-api-design.md`
**Implementation plan:** `docs/plans/2026-03-15-m1.3-grid-crud-api.md`

## Verification

```
npm run lint          → zero errors, zero warnings
npx tsc --noEmit      → clean
npm run test          → 87 tests passing (12 test files)
npm run test:coverage → 100% lines, 99%+ statements, 96%+ branches/functions (all >95%)
npm run build         → succeeds, all 4 routes visible
```

## Acceptance Criteria Checklists

### UC-1.3: Create Practice Grid

| Criterion | Status | Evidence |
|---|---|---|
| Grid requires a name (1-200 chars) | ✅ | `validateGridInput` in `src/models/grid.ts:24-33`, tests 2-5 |
| Notes are optional (no character limit) | ✅ | `validateGridInput` normalizes null/undefined, test 8 + test 11 (10,001 chars) |
| Grid is immediately visible in user's grid list | ✅ | Test 46 (create → list → delete → list verifies round-trip) |
| Grid stores created_at timestamp | ✅ | Test 24 (createdAt in response), Prisma schema `@default(now())` |
| Only the owning user can see/edit the grid | ✅ | Tests 28 (list isolation), 37 (detail 404 for other user), 43 (delete 404 for other user) |

### UC-1.3: Rejection Criteria

| Criterion | NOT Violated | Evidence |
|---|---|---|
| Grid created without user_id | ✅ Not violated | `createGrid` in controller always calls `getCurrentUserId()`, test 18 verifies userId at DB level |
| Grid visible to other users | ✅ Not violated | Tests 28, 37, 43 — other user's grids return 404 or are excluded from list |
| Grid created with empty/whitespace-only name | ✅ Not violated | Tests 2-3 (model unit), tests 21-22 (integration 400) |
| HTML/script tags rendered unescaped | ✅ Not violated | API stores as-is (tests 25-26), XSS prevention is frontend responsibility per design doc. JSON API does not render HTML. |

### UC-1.12: View Practice Grid (data layer only — UI deferred to M1.6)

| Criterion | Status | Evidence |
|---|---|---|
| Each cell displays target tempo (BPM, calculated from % × row target) | ✅ | `formatCell` in `src/views/grid.ts:68` computes `Math.round(targetTempoPercentage * rowTargetTempo)` |
| No floating-point artifacts in tempo display | ✅ | Test 17 (tempo rounding), `Math.round()` in view |
| Full nested data structure (grid → rows → cells → completions) | ✅ | Test 32 (full depth), `getGridById` includes 3-level nested query |
| Rows sorted by sortOrder, cells by stepNumber, completions by completionDate | ✅ | Tests 33, 34, 35 (all with out-of-order insertion to verify sorting) |

### UC-1.13: Delete Practice Grid (API-level — confirmation dialog deferred to M1.6)

| Criterion | Status | Evidence |
|---|---|---|
| Soft delete: sets deleted_at on grid AND cascades | ✅ | Test 40 (deletedAt set), test 41 (cascade to rows, cells, completions) |
| Grid disappears from list immediately | ✅ | Test 46 (list before and after delete) |
| Soft-deleted grid excluded from queries | ✅ | Tests 29 (list excludes), 38 (detail 404) |

### UC-1.13: Rejection Criteria

| Criterion | NOT Violated | Evidence |
|---|---|---|
| Hard delete (row physically removed) | ✅ Not violated | Tests 40-41 verify records still exist with deletedAt set (raw Prisma client) |
| User can delete grid they don't own | ✅ Not violated | Test 43 (other user's grid → 404) |
| Soft-deleted grid still appears in list | ✅ Not violated | Tests 29, 46 |
| Deletion without confirmation | ✅ N/A at API level | API performs delete unconditionally. Confirmation dialog is M1.6 (UI). |

### M1.3 Completion Criteria

| Criterion | Status |
|---|---|
| Schema migration adds `passageLabel` to PracticeRow | ✅ `20260315050448_add_passage_label_to_practice_row` |
| PRODUCT_SPEC.md updated with `passageLabel` | ✅ UC-1.4 updated with passage_label field |
| Auth placeholder and seed script in place | ✅ `src/lib/auth.ts` + `prisma/seed.ts` |
| All 4 endpoints follow MCV pattern | ✅ Model → Controller → View, routes are thin wrappers |
| All 46 planned test cases pass | ✅ 46 spec tests + 41 additional (coverage, error paths, infrastructure) = 87 total |
| `npm run lint && npx tsc --noEmit && npm run test && npm run build` passes | ✅ |

## Files Changed

| File | Change |
|---|---|
| `prisma/schema.prisma` | Add `passageLabel` to PracticeRow |
| `prisma/migrations/20260315050448_*` | Migration for passageLabel |
| `prisma/seed.ts` | Dev seed user (NEW) |
| `prisma.config.ts` | Add seed config |
| `src/lib/auth.ts` | Auth placeholder with cache reset (NEW) |
| `src/models/grid.ts` | Grid business logic — validation, CRUD, cascade (NEW) |
| `src/controllers/grid.ts` | HTTP orchestration (NEW) |
| `src/views/grid.ts` | Response formatting (NEW) |
| `src/app/api/grids/route.ts` | POST + GET collection routes (NEW) |
| `src/app/api/grids/[id]/route.ts` | GET + DELETE single resource routes (NEW) |
| `tests/unit/models/grid.test.ts` | 12 model validation tests (NEW) |
| `tests/unit/views/grid.test.ts` | 6 view formatting tests (NEW) |
| `tests/unit/lib/env.test.ts` | 2 env validation tests (NEW) |
| `tests/unit/lib/auth.test.ts` | 1 auth error path test (NEW) |
| `tests/integration/api/grids.test.ts` | 34 integration tests — CRUD + error handling (NEW) |
| `tests/integration/lib/soft-delete-extensions.test.ts` | 3 soft-delete extension tests (NEW) |
| `tests/setup.ts` | Add auth cache reset to afterEach |
| `package.json` | Add postinstall hook for prisma generate |
| `vitest.config.ts` | Exclude generated code from coverage |
| `eslint.config.mjs` | Add coverage directory to ignores |
| `docs/PRODUCT_SPEC.md` | Add passageLabel to UC-1.4 + entity table |
| `docs/plans/2026-03-15-m1.3-grid-crud-api-design.md` | Design doc (NEW) |
| `docs/plans/2026-03-15-m1.3-grid-crud-api.md` | Implementation plan (NEW) |

## Test plan

- [x] All 87 tests pass locally
- [x] Coverage exceeds 95% on all metrics
- [x] Lint: zero errors, zero warnings
- [x] TypeScript: clean compilation
- [x] Build: succeeds with all routes visible
- [ ] CI passes (pending)
- [ ] Willow reviews and approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)