### PR TITLE
feat: M1.5 Cell Completion & Freshness API

### DIFF
--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -284,18 +284,33 @@ Solid foundation: real user accounts, modernized infrastructure, and a polished 
   - Double-click creates duplicate completion records for the same cell on the same date
   - Completion percentage exceeds 100% or goes negative
 
-**UC-1.7: Uncomplete Practice Cell**
-- As a musician, I want to right-click or long-press a completed cell to undo the completion so that I can correct mistakes.
+**UC-1.7a: Undo Completion**
+- As a musician, I want to undo an accidental completion so that my practice data stays accurate.
 - Actor: Musician
 - Acceptance Criteria:
-  - Right-click or long-press on a completed cell removes its PracticeCellCompletion record
-  - Cell immediately transitions back to incomplete visual state
-  - Grid completion percentage recalculates
-  - If the cell had a freshness interval > 1 day (from prior spaced repetition), the interval resets to 1
+  - Soft-deletes the most recent PracticeCellCompletion record for the cell
+  - Cell immediately transitions back to its prior visual state
+  - Grid and row completion percentages recalculate
+  - Freshness interval is NOT restored to its prior value — the interval remains unchanged (undo corrects a misclick, not a practice history rewrite)
+  - If no active completions remain, cell returns to incomplete state with interval reset to 1
 - Rejection Criteria:
-  - Uncomplete leaves orphaned completion records in the database
-  - User can uncomplete a cell on a grid they don't own
-  - Grid completion percentage does not update after uncomplete
+  - Undo hard-deletes the completion record (must soft-delete)
+  - User can undo a completion on a grid they don't own
+  - Grid completion percentage does not update after undo
+  - Undo restores a prior freshness interval (interval is not rolled back)
+
+**UC-1.7b: Reset Cell**
+- As a musician, I want to reset a cell's freshness interval so that I can restart spaced repetition when I feel I've lost the skill.
+- Actor: Musician
+- Acceptance Criteria:
+  - Keeps all completion records intact (no deletions)
+  - Resets the cell's freshness_interval_days to 1
+  - Cell's freshness state recalculates based on new interval
+  - Grid and row completion percentages recalculate
+- Rejection Criteria:
+  - Reset deletes or soft-deletes any completion records
+  - User can reset a cell on a grid they don't own
+  - Grid completion percentage does not update after reset
 
 **UC-1.8: Freshness Decay (Spaced Repetition)**
 - As a musician, I expect my completed cells to gradually fade over time so that I'm reminded to maintain my skills, not just check boxes once and forget.
@@ -303,13 +318,13 @@ Solid foundation: real user accounts, modernized infrastructure, and a polished 
 - Acceptance Criteria:
   - Each cell tracks a freshness interval (initial: 1 day after first completion)
   - Re-practicing a cell before it goes stale doubles the interval (1→2→4→8→16→... days, capped at 30)
-  - Missing the interval resets it (configurable per user: full reset to 1, or halve)
+  - Missing the interval resets it to 1 day (full reset)
   - Cell visual states based on time since last completion relative to interval:
     - **Fresh** (green): within the first 50% of the interval
     - **Aging** (yellow/fading green): 50%-100% through the interval
     - **Stale** (orange/red): past the interval but within 2x
     - **Decayed** (grey): more than 2x past the interval
-  - Decayed cells no longer count toward grid completion percentage
+  - Only decayed and incomplete cells do not count toward grid completion percentage (fresh, aging, and stale all count)
   - Freshness is calculated on read (derived from last completion date + current interval), not stored as separate state
 - Rejection Criteria:
   - Freshness interval stored incorrectly after re-practice (must exactly double, not approximate)
@@ -341,7 +356,7 @@ Solid foundation: real user accounts, modernized infrastructure, and a polished 
   - **Fade OFF:** completions are permanent — classic checkbox behavior, solid green stays green forever
   - Default for new grids: fade ON (configurable in user preferences)
   - Toggling fade off does NOT delete freshness data — toggling back on restores the decay view with current state
-  - Grid completion percentage calculation adjusts: fade ON = only fresh+aging count; fade OFF = all completions count
+  - Grid completion percentage calculation adjusts: fade ON = fresh+aging+stale count (stale is a warning, not failure); fade OFF = all completions count
 - Rejection Criteria:
   - Toggling fade off deletes or corrupts freshness interval data
   - Grid completion percentage doesn't recalculate when fade is toggled
@@ -1944,7 +1959,6 @@ The central identity. Every piece of data in the system is owned by or attribute
 | email_verified | boolean | System-set on verification | Default false. Set true when verification token consumed |
 | timezone | string | User-provided or detected | IANA timezone (e.g., "America/Chicago"). Used for streak/freshness calculations |
 | default_fade_enabled | boolean | User preference | Default true. Applied to new grids |
-| freshness_reset_strategy | enum(full, halve) | User preference | Default: full. When a cell's freshness interval expires: 'full' resets to 1 day, 'halve' cuts interval in half |
 | created_at | timestamptz | System-generated | Immutable |
 | updated_at | timestamptz | System-generated | Auto-updated on any field change |
 | stripe_customer_id | string, nullable | System-set on first Stripe interaction (V4) | Immutable once set |
@@ -1993,7 +2007,7 @@ A structured practice plan for a piece of music or collection of technical studi
 | deleted_at | timestamptz, nullable | System-set on soft delete | Null = active. Non-null = soft-deleted |
 
 **Derived values (never stored):**
-- `completion_percentage`: count of fresh+aging cells / total cells (fade on) OR completed cells / total cells (fade off)
+- `completion_percentage`: count of fresh+aging+stale cells / total cells (fade on) OR completed cells / total cells (fade off). Rationale: stale is a warning state, not a failure — the musician practiced the material and it hasn't fully decayed yet
 - `total_cells`: sum of all cells across all rows
 - `stale_cell_count`: count of cells in stale or decayed state
 - `last_practiced_at`: max(completion_date) across all cells in this grid
@@ -2045,7 +2059,7 @@ A segment of music within a grid — a specific passage, measure range, or techn
 **Derived values:**
 - `completion_percentage`: computed from child cells' freshness state
 - `max_fresh_tempo_percentage`: highest target_tempo_percentage among fresh/aging cells
-- `freshness_summary`: { fresh: N, aging: N, stale: N, decayed: N }
+- `freshness_summary`: { fresh: N, aging: N, stale: N, decayed: N, incomplete: N }
 
 **Research value:** Row-level data enables per-passage analysis: which measure ranges are hardest (most re-practices), how tempo progression correlates with mastery, priority vs actual practice frequency.
 
@@ -2060,7 +2074,7 @@ A single tempo step within a row. Represents "practice this passage at this perc
 | practice_row_id | FK→PracticeRow | System-set at creation | Immutable. Cascading delete |
 | step_number | integer | System-set at creation | 0-indexed position. Used for tempo calculation |
 | target_tempo_percentage | float | System-calculated at creation | Formula: 0.4 + (0.6 * step_number / (total_steps - 1)). Calculated at cell creation. Stored. Only recalculated if steps change (which regenerates all cells) |
-| freshness_interval_days | integer | System-managed | Default: 1. Doubles on re-practice (cap 30). Resets on uncomplete |
+| freshness_interval_days | integer | System-managed | Default: 1. Doubles on re-practice (cap 30). Resets to 1 on cell reset (UC-1.7b). Unchanged on undo (UC-1.7a) |
 | created_at | timestamptz | System-generated | Immutable |
 | updated_at | timestamptz | System-generated | Auto-updated (interval changes) |
 | deleted_at | timestamptz, nullable | System-set on soft delete | Null = active. Non-null = soft-deleted |
@@ -2640,7 +2654,7 @@ A milestone is complete when all its tasks pass their mapped acceptance criteria
 - Task: Write and run database migrations
 - Task: Write unit tests for domain model constraints (required fields, enums, FK integrity)
 - Task: Document domain model in auto-generated schema docs
-- Maps to: UC-1.3, UC-1.4 (data layer), UC-1.7, UC-1.8, UC-1.9, UC-1.10
+- Maps to: UC-1.3, UC-1.4 (data layer), UC-1.7a, UC-1.7b, UC-1.8, UC-1.9, UC-1.10
 
 **M1.3: Grid CRUD API**
 - Task: Create grid endpoint (POST) — validates name, sets user_id, defaults
@@ -2662,14 +2676,15 @@ A milestone is complete when all its tasks pass their mapped acceptance criteria
 
 **M1.5: Cell Completion & Freshness API**
 - Task: Complete cell endpoint (POST) — creates PracticeCellCompletion, updates freshness interval
-- Task: Uncomplete cell endpoint (DELETE) — removes completion, resets interval
+- Task: Undo completion endpoint (DELETE) — soft-deletes most recent completion
+- Task: Reset cell endpoint (POST) — resets freshness interval to 1
 - Task: Write freshness calculation logic (pure function: last_completion_date + interval → state)
 - Task: Write cascading fade logic (pure function: within a row, highest tempo fades first)
 - Task: Configure fade toggle endpoint (PUT on PracticeGrid.fade_enabled)
 - Task: Write grid completion percentage calculation (respects fade on/off)
 - Task: Unit tests for: interval doubling, interval cap (30 days), cascade ordering, completion % with/without fade
 - Task: Integration tests for completion lifecycle
-- Maps to: UC-1.6, UC-1.7, UC-1.8, UC-1.9, UC-1.10
+- Maps to: UC-1.6, UC-1.7a, UC-1.7b, UC-1.8, UC-1.9, UC-1.10
 
 **M1.6: Grid View UI**
 - Task: Build grid view component — rows, cells, tempo display
@@ -2681,7 +2696,7 @@ A milestone is complete when all its tasks pass their mapped acceptance criteria
 - Task: Progress bar showing grid completion %
 - Task: Responsive layout (320px+ viewports, adapts to large step counts)
 - Task: Playwright e2e tests with screenshots for each visual state
-- Maps to: UC-1.6, UC-1.7, UC-1.11, UC-1.12
+- Maps to: UC-1.6, UC-1.7a, UC-1.7b, UC-1.11, UC-1.12
 
 **M1.7: Dashboard UI**
 - Task: Build 4-quadrant dashboard layout (responsive: 2x2 desktop, stacked mobile)
@@ -3153,3 +3168,17 @@ At the end of each milestone's final task, verify the milestone as a whole:
 - Export integrity: CSV opens correctly in Excel and Google Sheets
 - PDF export: renders correctly with Unicode characters, long names, empty data
 - Challenge manipulation: attempt to backdate practice entries during active challenge
+
+---
+
+## Future Enhancements
+
+The following features are explicitly deferred and not part of any current milestone. They are recorded here to prevent re-discovery and to guide future design decisions.
+
+**Configurable Practice Enforcement**
+- Allow users to choose their interval reset strategy when a cell's freshness expires: full reset to 1 day (current default), halve the interval, or a custom reset factor.
+- This was considered for V1 (M1.5) but deferred to keep the initial implementation simple. The `freshness_interval_days` field on PracticeCell is already designed to support alternative strategies — only the reset logic needs to change.
+
+**User-Local Practice Days**
+- Allow users to set their timezone so that "today" reflects their local date instead of UTC for freshness calculations and streak tracking.
+- The User entity already includes a `timezone` field (IANA format). The infrastructure is in place but freshness calculations currently use UTC dates. A future milestone should wire the user's timezone into all date-sensitive operations (freshness state computation, completion date assignment, streak boundaries).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "tessitura",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",

--- a/prisma/migrations/20260316062703_remove_freshness_reset_strategy/migration.sql
+++ b/prisma/migrations/20260316062703_remove_freshness_reset_strategy/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `freshness_reset_strategy` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "pieces" ALTER COLUMN "updated_at" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "freshness_reset_strategy";
+
+-- DropEnum
+DROP TYPE "FreshnessResetStrategy";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,11 +9,6 @@ datasource db {
 
 // ── Enums ──────────────────────────────────────────────────────────
 
-enum FreshnessResetStrategy {
-  FULL
-  HALVE
-}
-
 enum Priority {
   CRITICAL
   HIGH
@@ -32,7 +27,6 @@ model User {
   emailVerified          Boolean                @default(false) @map("email_verified")
   timezone               String                 @default("UTC")
   defaultFadeEnabled     Boolean                @default(true) @map("default_fade_enabled")
-  freshnessResetStrategy FreshnessResetStrategy @default(FULL) @map("freshness_reset_strategy")
   createdAt              DateTime               @default(now()) @map("created_at") @db.Timestamptz
   updatedAt              DateTime               @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt              DateTime?              @map("deleted_at") @db.Timestamptz

--- a/src/app/api/grids/[id]/fade/route.ts
+++ b/src/app/api/grids/[id]/fade/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { updateFade } from '@/controllers/grid';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return updateFade(id, request);
+}

--- a/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/complete/route.ts
+++ b/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/complete/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { completeCell } from '@/controllers/cell';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; rowId: string; cellId: string }> },
+) {
+  const { id, rowId, cellId } = await params;
+  return completeCell(id, rowId, cellId);
+}

--- a/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/reset/route.ts
+++ b/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/reset/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { resetCell } from '@/controllers/cell';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; rowId: string; cellId: string }> },
+) {
+  const { id, rowId, cellId } = await params;
+  return resetCell(id, rowId, cellId);
+}

--- a/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/undo/route.ts
+++ b/src/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/undo/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { undoCompletion } from '@/controllers/cell';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; rowId: string; cellId: string }> },
+) {
+  const { id, rowId, cellId } = await params;
+  return undoCompletion(id, rowId, cellId);
+}

--- a/src/controllers/cell.ts
+++ b/src/controllers/cell.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserId } from '@/lib/auth';
+import { AuthenticationError, ValidationError, ConflictError } from '@/lib/errors';
+import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
+import {
+  completeCell as completeCellModel,
+  undoCompletion as undoCompletionModel,
+  resetCell as resetCellModel,
+} from '@/models/cell';
+import { formatCellResponse } from '@/views/row';
+
+export async function completeCell(gridId: string, rowId: string, cellId: string) {
+  try {
+    if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
+      return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const cell = await completeCellModel(gridId, rowId, cellId, userId);
+    if (!cell) {
+      return errorResponse('Cell not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatCellResponse(cell), { status: 201 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ConflictError) {
+      return errorResponse(error.message, 'CONFLICT', 409);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    // P2002 unique constraint violation = concurrent race
+    if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002') {
+      return errorResponse('Cell already completed today', 'CONFLICT', 409);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function undoCompletion(gridId: string, rowId: string, cellId: string) {
+  try {
+    if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
+      return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const cell = await undoCompletionModel(gridId, rowId, cellId, userId);
+    if (!cell) {
+      return errorResponse('Cell not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatCellResponse(cell));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ConflictError) {
+      return errorResponse(error.message, 'CONFLICT', 409);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function resetCell(gridId: string, rowId: string, cellId: string) {
+  try {
+    if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
+      return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const cell = await resetCellModel(gridId, rowId, cellId, userId);
+    if (!cell) {
+      return errorResponse('Cell not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatCellResponse(cell));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ConflictError) {
+      return errorResponse(error.message, 'CONFLICT', 409);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/controllers/cell.ts
+++ b/src/controllers/cell.ts
@@ -46,7 +46,7 @@ export async function undoCompletion(gridId: string, rowId: string, cellId: stri
     }
     const now = new Date();
     const userId = await getCurrentUserId();
-    const cell = await undoCompletionModel(gridId, rowId, cellId, userId);
+    const cell = await undoCompletionModel(gridId, rowId, cellId, userId, now);
     if (!cell) {
       return errorResponse('Cell not found', 'NOT_FOUND', 404);
     }

--- a/src/controllers/cell.ts
+++ b/src/controllers/cell.ts
@@ -14,12 +14,13 @@ export async function completeCell(gridId: string, rowId: string, cellId: string
     if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
       return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
     }
+    const now = new Date();
     const userId = await getCurrentUserId();
-    const cell = await completeCellModel(gridId, rowId, cellId, userId);
+    const cell = await completeCellModel(gridId, rowId, cellId, userId, now);
     if (!cell) {
       return errorResponse('Cell not found', 'NOT_FOUND', 404);
     }
-    return NextResponse.json(formatCellResponse(cell), { status: 201 });
+    return NextResponse.json(formatCellResponse(cell, now), { status: 201 });
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -43,12 +44,13 @@ export async function undoCompletion(gridId: string, rowId: string, cellId: stri
     if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
       return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
     }
+    const now = new Date();
     const userId = await getCurrentUserId();
     const cell = await undoCompletionModel(gridId, rowId, cellId, userId);
     if (!cell) {
       return errorResponse('Cell not found', 'NOT_FOUND', 404);
     }
-    return NextResponse.json(formatCellResponse(cell));
+    return NextResponse.json(formatCellResponse(cell, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -65,12 +67,13 @@ export async function resetCell(gridId: string, rowId: string, cellId: string) {
     if (!UUID_REGEX.test(gridId) || !UUID_REGEX.test(rowId) || !UUID_REGEX.test(cellId)) {
       return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
     }
+    const now = new Date();
     const userId = await getCurrentUserId();
     const cell = await resetCellModel(gridId, rowId, cellId, userId);
     if (!cell) {
       return errorResponse('Cell not found', 'NOT_FOUND', 404);
     }
-    return NextResponse.json(formatCellResponse(cell));
+    return NextResponse.json(formatCellResponse(cell, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);

--- a/src/controllers/grid.ts
+++ b/src/controllers/grid.ts
@@ -5,6 +5,7 @@ import {
   listGrids as listGridsModel,
   getGridById,
   deleteGrid as deleteGridModel,
+  updateGridFade,
 } from '@/models/grid';
 import { AuthenticationError, ValidationError } from '@/lib/errors';
 import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
@@ -89,6 +90,29 @@ export async function deleteGrid(gridId: string) {
     }
 
     return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function updateFade(gridId: string, request: NextRequest) {
+  try {
+    if (!UUID_REGEX.test(gridId)) {
+      return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body.fadeEnabled !== 'boolean') {
+      return errorResponse('fadeEnabled (boolean) is required', 'VALIDATION_ERROR', 400);
+    }
+    const grid = await updateGridFade(gridId, userId, body.fadeEnabled);
+    if (!grid) {
+      return errorResponse('Grid not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatGridDetail(grid));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);

--- a/src/controllers/grid.ts
+++ b/src/controllers/grid.ts
@@ -60,6 +60,7 @@ export async function getGrid(gridId: string) {
       return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
     }
 
+    const now = new Date();
     const userId = await getCurrentUserId();
     const grid = await getGridById(gridId, userId);
 
@@ -67,7 +68,7 @@ export async function getGrid(gridId: string) {
       return errorResponse('Grid not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatGridDetail(grid));
+    return NextResponse.json(formatGridDetail(grid, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -103,6 +104,7 @@ export async function updateFade(gridId: string, request: NextRequest) {
     if (!UUID_REGEX.test(gridId)) {
       return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
     }
+    const now = new Date();
     const userId = await getCurrentUserId();
     const body = await request.json().catch(() => null);
     if (!body || typeof body.fadeEnabled !== 'boolean') {
@@ -112,7 +114,7 @@ export async function updateFade(gridId: string, request: NextRequest) {
     if (!grid) {
       return errorResponse('Grid not found', 'NOT_FOUND', 404);
     }
-    return NextResponse.json(formatGridDetail(grid));
+    return NextResponse.json(formatGridDetail(grid, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);

--- a/src/controllers/row.ts
+++ b/src/controllers/row.ts
@@ -16,6 +16,7 @@ export async function createRow(gridId: string, request: NextRequest) {
       return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
     }
 
+    const now = new Date();
     const userId = await getCurrentUserId();
     const body = await request.json().catch(() => null);
 
@@ -51,7 +52,7 @@ export async function createRow(gridId: string, request: NextRequest) {
       return errorResponse('Grid not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(result.row, result.fadeEnabled), { status: 201 });
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled, now), { status: 201 });
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -69,6 +70,7 @@ export async function updateRow(gridId: string, rowId: string, request: NextRequ
       return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
     }
 
+    const now = new Date();
     const userId = await getCurrentUserId();
     const body = await request.json().catch(() => null);
 
@@ -97,7 +99,7 @@ export async function updateRow(gridId: string, rowId: string, request: NextRequ
       return errorResponse('Row not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(result.row, result.fadeEnabled));
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -115,6 +117,7 @@ export async function updatePriority(gridId: string, rowId: string, request: Nex
       return errorResponse('Invalid ID format', 'VALIDATION_ERROR', 400);
     }
 
+    const now = new Date();
     const userId = await getCurrentUserId();
     const body = await request.json().catch(() => null);
 
@@ -128,7 +131,7 @@ export async function updatePriority(gridId: string, rowId: string, request: Nex
       return errorResponse('Row not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(result.row, result.fadeEnabled));
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled, now));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);

--- a/src/controllers/row.ts
+++ b/src/controllers/row.ts
@@ -38,7 +38,7 @@ export async function createRow(gridId: string, request: NextRequest) {
       return errorResponse('passageLabel must be a string', 'VALIDATION_ERROR', 400);
     }
 
-    const row = await createRowModel(gridId, userId, {
+    const result = await createRowModel(gridId, userId, {
       startMeasure: body.startMeasure,
       endMeasure: body.endMeasure,
       targetTempo: body.targetTempo,
@@ -47,11 +47,11 @@ export async function createRow(gridId: string, request: NextRequest) {
       passageLabel: body.passageLabel ?? null,
     });
 
-    if (!row) {
+    if (!result) {
       return errorResponse('Grid not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(row), { status: 201 });
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled), { status: 201 });
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -91,13 +91,13 @@ export async function updateRow(gridId: string, rowId: string, request: NextRequ
       return errorResponse('passageLabel must be a string', 'VALIDATION_ERROR', 400);
     }
 
-    const row = await updateRowModel(gridId, rowId, userId, body);
+    const result = await updateRowModel(gridId, rowId, userId, body);
 
-    if (!row) {
+    if (!result) {
       return errorResponse('Row not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(row));
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
@@ -122,13 +122,13 @@ export async function updatePriority(gridId: string, rowId: string, request: Nex
       return errorResponse('Priority is required', 'VALIDATION_ERROR', 400);
     }
 
-    const row = await updateRowPriorityModel(gridId, rowId, userId, body.priority);
+    const result = await updateRowPriorityModel(gridId, rowId, userId, body.priority);
 
-    if (!row) {
+    if (!result) {
       return errorResponse('Row not found', 'NOT_FOUND', 404);
     }
 
-    return NextResponse.json(formatRow(row));
+    return NextResponse.json(formatRow(result.row, result.fadeEnabled));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -20,3 +20,10 @@ export class AuthenticationError extends Error {
     this.name = 'AuthenticationError';
   }
 }
+
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -1,0 +1,216 @@
+import { prisma } from '@/lib/db';
+import { ConflictError } from '@/lib/errors';
+import { calculateFreshnessState, calculateNewInterval } from '@/models/freshness';
+
+type TransactionClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
+
+/**
+ * Validates ownership chain (grid → row → cell) INSIDE a transaction.
+ * Returns the cell with non-deleted completions ordered by completionDate asc,
+ * or null if any part of the chain is not found / not owned.
+ *
+ * Soft-delete visibility: grid, row, cell all filtered by deletedAt IS NULL.
+ */
+async function findOwnedCell(
+  tx: TransactionClient,
+  gridId: string,
+  rowId: string,
+  cellId: string,
+  userId: string,
+) {
+  const grid = await tx.practiceGrid.findFirst({
+    where: { id: gridId, userId, deletedAt: null },
+  });
+  if (!grid) return null;
+
+  const row = await tx.practiceRow.findFirst({
+    where: { id: rowId, practiceGridId: gridId, deletedAt: null },
+  });
+  if (!row) return null;
+
+  return tx.practiceCell.findFirst({
+    where: { id: cellId, practiceRowId: rowId, deletedAt: null },
+    include: {
+      completions: {
+        where: { deletedAt: null },
+        orderBy: { completionDate: 'asc' },
+      },
+    },
+  });
+}
+
+/**
+ * Include clause for returning a cell with siblings for shielding computation.
+ * Completions ordered by completionDate asc — last element is most recent (intentional).
+ */
+const CELL_RETURN_INCLUDE = {
+  completions: {
+    where: { deletedAt: null },
+    orderBy: { completionDate: 'asc' as const },
+  },
+  practiceRow: {
+    select: {
+      targetTempo: true,
+      practiceGrid: { select: { fadeEnabled: true } },
+      practiceCells: {
+        where: { deletedAt: null },
+        orderBy: { stepNumber: 'asc' as const },
+        include: {
+          completions: {
+            where: { deletedAt: null },
+            orderBy: { completionDate: 'asc' as const },
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Returns midnight UTC today as a Date.
+ * Used for completionDate which is @db.Date in Prisma schema.
+ */
+function todayUTC(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+/**
+ * Records a completion for today on the given cell.
+ *
+ * Business rules:
+ * - If a non-deleted completion exists for today → ConflictError
+ * - If a soft-deleted completion exists for today → un-soft-delete it (undo-then-redo)
+ * - Otherwise → create a new completion
+ * - Updates freshnessIntervalDays based on current state
+ *
+ * Returns cell with CELL_RETURN_INCLUDE for formatCellResponse, or null if not found.
+ */
+export async function completeCell(gridId: string, rowId: string, cellId: string, userId: string) {
+  return prisma.$transaction(async (tx) => {
+    const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
+    if (!cell) return null;
+
+    const today = todayUTC();
+    const now = new Date();
+
+    // Check for existing completion today (including soft-deleted).
+    // Explicit `deletedAt` key bypasses the soft-delete extension filter;
+    // `undefined` value tells Prisma "no filter on this field".
+    const existing = await tx.practiceCellCompletion.findFirst({
+      where: {
+        practiceCellId: cellId,
+        completionDate: today,
+        deletedAt: undefined,
+      },
+    });
+
+    if (existing && existing.deletedAt === null) {
+      throw new ConflictError('Cell already completed today');
+    }
+
+    if (existing && existing.deletedAt !== null) {
+      // Un-soft-delete (undo-then-redo case)
+      await tx.practiceCellCompletion.update({
+        where: { id: existing.id },
+        data: { deletedAt: null },
+      });
+    } else {
+      await tx.practiceCellCompletion.create({
+        data: { practiceCellId: cellId, completionDate: today },
+      });
+    }
+
+    // Calculate new interval: first completion → 'incomplete' state, otherwise use raw state
+    const rawState = calculateFreshnessState(today, cell.freshnessIntervalDays, now);
+    const stateForInterval = cell.completions.length === 0 ? 'incomplete' : rawState;
+    const newInterval = calculateNewInterval(cell.freshnessIntervalDays, stateForInterval);
+
+    await tx.practiceCell.update({
+      where: { id: cellId },
+      data: { freshnessIntervalDays: newInterval },
+    });
+
+    return tx.practiceCell.findUniqueOrThrow({
+      where: { id: cellId },
+      include: CELL_RETURN_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Soft-deletes the most recent completion for the given cell.
+ *
+ * Business rules:
+ * - If no non-deleted completions exist → ConflictError
+ * - Soft-deletes the last completion (most recent by completionDate asc order)
+ * - Re-counts remaining completions INSIDE the transaction
+ * - If 0 remain → resets interval to 1
+ *
+ * Returns cell with CELL_RETURN_INCLUDE for formatCellResponse, or null if not found.
+ */
+export async function undoCompletion(gridId: string, rowId: string, cellId: string, userId: string) {
+  return prisma.$transaction(async (tx) => {
+    const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
+    if (!cell) return null;
+
+    if (cell.completions.length === 0) {
+      throw new ConflictError('No completions to undo');
+    }
+
+    // Last element is most recent (ordered by completionDate asc)
+    const mostRecent = cell.completions[cell.completions.length - 1];
+    await tx.practiceCellCompletion.update({
+      where: { id: mostRecent.id },
+      data: { deletedAt: new Date() },
+    });
+
+    // Re-count INSIDE tx (not from pre-fetch) to ensure ACID correctness
+    const remainingCount = await tx.practiceCellCompletion.count({
+      where: { practiceCellId: cellId, deletedAt: null },
+    });
+
+    if (remainingCount === 0) {
+      await tx.practiceCell.update({
+        where: { id: cellId },
+        data: { freshnessIntervalDays: 1 },
+      });
+    }
+
+    return tx.practiceCell.findUniqueOrThrow({
+      where: { id: cellId },
+      include: CELL_RETURN_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Resets the freshness interval of the given cell to 1 day.
+ * Does NOT delete any completion records.
+ *
+ * Business rules:
+ * - If no completions exist → ConflictError (nothing to reset)
+ * - Sets freshnessIntervalDays to 1
+ *
+ * Returns cell with CELL_RETURN_INCLUDE for formatCellResponse, or null if not found.
+ */
+export async function resetCell(gridId: string, rowId: string, cellId: string, userId: string) {
+  return prisma.$transaction(async (tx) => {
+    const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
+    if (!cell) return null;
+
+    if (cell.completions.length === 0) {
+      throw new ConflictError('No completions to reset');
+    }
+
+    await tx.practiceCell.update({
+      where: { id: cellId },
+      data: { freshnessIntervalDays: 1 },
+    });
+
+    return tx.practiceCell.findUniqueOrThrow({
+      where: { id: cellId },
+      include: CELL_RETURN_INCLUDE,
+    });
+  });
+}

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -121,8 +121,12 @@ export async function completeCell(gridId: string, rowId: string, cellId: string
       });
     }
 
-    // Calculate new interval: first completion → 'incomplete' state, otherwise use raw state
-    const rawState = calculateFreshnessState(today, cell.freshnessIntervalDays, now);
+    // Calculate new interval based on cell's state BEFORE this completion.
+    // Use the prior last completion date (not today) so stale/decayed cells get interval reset to 1.
+    const priorLastCompletion = cell.completions.length > 0
+      ? cell.completions[cell.completions.length - 1].completionDate
+      : null;
+    const rawState = calculateFreshnessState(priorLastCompletion, cell.freshnessIntervalDays, now);
     const stateForInterval = cell.completions.length === 0 ? 'incomplete' : rawState;
     const newInterval = calculateNewInterval(cell.freshnessIntervalDays, stateForInterval);
 

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -86,13 +86,12 @@ function todayUTC(): Date {
  *
  * Returns cell with CELL_RETURN_INCLUDE for formatCellResponse, or null if not found.
  */
-export async function completeCell(gridId: string, rowId: string, cellId: string, userId: string) {
+export async function completeCell(gridId: string, rowId: string, cellId: string, userId: string, now: Date) {
   return prisma.$transaction(async (tx) => {
     const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
     if (!cell) return null;
 
     const today = todayUTC();
-    const now = new Date();
 
     // Check for existing completion today (including soft-deleted).
     // Explicit `deletedAt` key bypasses the soft-delete extension filter;

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -67,11 +67,11 @@ const CELL_RETURN_INCLUDE = {
 };
 
 /**
- * Returns midnight UTC today as a Date.
+ * Truncates a Date to midnight UTC (date-only).
  * Used for completionDate which is @db.Date in Prisma schema.
+ * Derives from the caller's `now` — never samples the clock itself.
  */
-function todayUTC(): Date {
-  const now = new Date();
+export function dateOnlyUTC(now: Date): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
@@ -91,7 +91,7 @@ export async function completeCell(gridId: string, rowId: string, cellId: string
     const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
     if (!cell) return null;
 
-    const today = todayUTC();
+    const today = dateOnlyUTC(now);
 
     // Check for existing completion today (including soft-deleted).
     // Explicit `deletedAt` key bypasses the soft-delete extension filter;
@@ -152,7 +152,7 @@ export async function completeCell(gridId: string, rowId: string, cellId: string
  *
  * Returns cell with CELL_RETURN_INCLUDE for formatCellResponse, or null if not found.
  */
-export async function undoCompletion(gridId: string, rowId: string, cellId: string, userId: string) {
+export async function undoCompletion(gridId: string, rowId: string, cellId: string, userId: string, now: Date) {
   return prisma.$transaction(async (tx) => {
     const cell = await findOwnedCell(tx, gridId, rowId, cellId, userId);
     if (!cell) return null;
@@ -165,7 +165,7 @@ export async function undoCompletion(gridId: string, rowId: string, cellId: stri
     const mostRecent = cell.completions[cell.completions.length - 1];
     await tx.practiceCellCompletion.update({
       where: { id: mostRecent.id },
-      data: { deletedAt: new Date() },
+      data: { deletedAt: now },
     });
 
     // Re-count INSIDE tx (not from pre-fetch) to ensure ACID correctness

--- a/src/models/freshness.ts
+++ b/src/models/freshness.ts
@@ -79,3 +79,37 @@ export function effectiveFreshnessState(
   if (isShieldedFlag) return 'fresh';
   return rawState;
 }
+
+// ─── Task 4: Completion Percentage + Summary ─────────────────────────────────
+
+export interface CellWithEffectiveState {
+  effectiveState: FreshnessState;
+}
+
+export function calculateCompletionPercentage(
+  cells: CellWithEffectiveState[],
+  fadeEnabled: boolean,
+): number {
+  if (cells.length === 0) return 0;
+
+  const countCompleted = fadeEnabled
+    ? cells.filter(
+        (c) =>
+          c.effectiveState === 'fresh' ||
+          c.effectiveState === 'aging' ||
+          c.effectiveState === 'stale',
+      ).length
+    : cells.filter((c) => c.effectiveState !== 'incomplete').length;
+
+  return (countCompleted / cells.length) * 100;
+}
+
+export function calculateFreshnessSummary(
+  cells: CellWithEffectiveState[],
+): { fresh: number; aging: number; stale: number; decayed: number; incomplete: number } {
+  const summary = { fresh: 0, aging: 0, stale: 0, decayed: 0, incomplete: 0 };
+  for (const cell of cells) {
+    summary[cell.effectiveState]++;
+  }
+  return summary;
+}

--- a/src/models/freshness.ts
+++ b/src/models/freshness.ts
@@ -40,3 +40,42 @@ export function calculateNewInterval(
       return 1;
   }
 }
+
+// ─── Task 3: Shielding + Effective State ────────────────────────────────────
+
+export interface CellWithState {
+  rawState: FreshnessState;
+  hasCompletions: boolean;
+}
+
+export function isShielded(
+  cellIndex: number,
+  cells: CellWithState[],
+  fadeEnabled: boolean,
+): boolean {
+  if (!fadeEnabled) return false;
+
+  const cell = cells[cellIndex];
+  if (!cell.hasCompletions) return false;
+
+  // Find next higher completed cell (skip incomplete cells)
+  for (let i = cellIndex + 1; i < cells.length; i++) {
+    if (cells[i].hasCompletions) {
+      return cells[i].rawState !== 'decayed';
+    }
+  }
+
+  // No higher completed cell — this is the highest, fades first
+  return false;
+}
+
+export function effectiveFreshnessState(
+  rawState: FreshnessState,
+  isShieldedFlag: boolean,
+  fadeEnabled: boolean,
+): FreshnessState {
+  if (rawState === 'incomplete') return 'incomplete';
+  if (!fadeEnabled) return 'fresh';
+  if (isShieldedFlag) return 'fresh';
+  return rawState;
+}

--- a/src/models/freshness.ts
+++ b/src/models/freshness.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure freshness calculation functions.
+ * No database access — every function accepts a `now` parameter for testability.
+ *
+ * Design doc: docs/plans/2026-03-16-m1.5-cell-completion-freshness-design.md
+ */
+
+export type FreshnessState = 'incomplete' | 'fresh' | 'aging' | 'stale' | 'decayed';
+
+const MS_PER_DAY = 86_400_000;
+const MAX_INTERVAL = 30;
+
+export function calculateFreshnessState(
+  lastCompletionDate: Date | null,
+  intervalDays: number,
+  now: Date,
+): FreshnessState {
+  if (lastCompletionDate === null) return 'incomplete';
+
+  const daysSince = Math.floor((now.getTime() - lastCompletionDate.getTime()) / MS_PER_DAY);
+
+  if (daysSince <= intervalDays * 0.5) return 'fresh';
+  if (daysSince <= intervalDays) return 'aging';
+  if (daysSince <= intervalDays * 2) return 'stale';
+  return 'decayed';
+}
+
+export function calculateNewInterval(
+  currentInterval: number,
+  rawState: FreshnessState,
+): number {
+  switch (rawState) {
+    case 'incomplete':
+      return 1;
+    case 'fresh':
+    case 'aging':
+      return Math.min(currentInterval * 2, MAX_INTERVAL);
+    case 'stale':
+    case 'decayed':
+      return 1;
+  }
+}

--- a/src/models/freshness.ts
+++ b/src/models/freshness.ts
@@ -2,7 +2,7 @@
  * Pure freshness calculation functions.
  * No database access — every function accepts a `now` parameter for testability.
  *
- * Design doc: docs/plans/2026-03-16-m1.5-cell-completion-freshness-design.md
+ * Design doc: docs/specs/2026-03-16-m1.5-cell-completion-freshness-design.md
  */
 
 export type FreshnessState = 'incomplete' | 'fresh' | 'aging' | 'stale' | 'decayed';

--- a/src/models/grid.ts
+++ b/src/models/grid.ts
@@ -114,6 +114,22 @@ export async function getGridById(gridId: string, userId: string) {
 }
 
 /**
+ * Updates the fadeEnabled flag on a grid.
+ * Returns the full grid detail (via getGridById), or null if not found/not owned.
+ */
+export async function updateGridFade(gridId: string, userId: string, fadeEnabled: boolean) {
+  const grid = await findOwnedGrid(gridId, userId);
+  if (!grid) return null;
+
+  await prisma.practiceGrid.update({
+    where: { id: gridId },
+    data: { fadeEnabled },
+  });
+
+  return getGridById(gridId, userId);
+}
+
+/**
  * Soft-deletes a grid and all children in a single transaction.
  * Returns true if deleted, false if not found/not owned.
  */

--- a/src/models/row.ts
+++ b/src/models/row.ts
@@ -124,9 +124,12 @@ async function findOwnedRow(gridId: string, rowId: string, userId: string) {
   const grid = await findOwnedGrid(gridId, userId);
   if (!grid) return null;
 
-  return prisma.practiceRow.findFirst({
+  const row = await prisma.practiceRow.findFirst({
     where: { id: rowId, practiceGridId: gridId, deletedAt: null },
   });
+  if (!row) return null;
+
+  return { row, fadeEnabled: grid.fadeEnabled };
 }
 
 /**
@@ -154,7 +157,7 @@ export async function createRow(gridId: string, userId: string, input: RowInput)
 
   const percentages = generateCellPercentages(validated.steps);
 
-  return prisma.$transaction(async (tx) => {
+  const row = await prisma.$transaction(async (tx) => {
     // Atomic sortOrder assignment
     const maxResult = await tx.$queryRawUnsafe<[{ max: number | null }]>(
       `SELECT MAX(sort_order) as max FROM practice_rows WHERE practice_grid_id = $1 AND deleted_at IS NULL`,
@@ -208,12 +211,15 @@ export async function createRow(gridId: string, userId: string, input: RowInput)
       },
     });
   });
+
+  return { row, fadeEnabled: grid.fadeEnabled };
 }
 
 export async function updateRow(gridId: string, rowId: string, userId: string, input: RowUpdateInput) {
-  const existingRow = await findOwnedRow(gridId, rowId, userId);
-  if (!existingRow) return null;
+  const found = await findOwnedRow(gridId, rowId, userId);
+  if (!found) return null;
 
+  const { row: existingRow, fadeEnabled } = found;
   const validated = validateRowUpdate(input);
 
   // Cross-field validation with existing values
@@ -229,7 +235,7 @@ export async function updateRow(gridId: string, rowId: string, userId: string, i
 
   const stepsChanged = validated.steps != null && validated.steps !== existingRow.steps;
 
-  return prisma.$transaction(async (tx) => {
+  const row = await prisma.$transaction(async (tx) => {
     // Update row fields
     const rowData: Record<string, unknown> = {};
     if (validated.startMeasure !== undefined) rowData.startMeasure = validated.startMeasure;
@@ -297,6 +303,8 @@ export async function updateRow(gridId: string, rowId: string, userId: string, i
       },
     });
   });
+
+  return { row, fadeEnabled };
 }
 
 export async function updateRowPriority(
@@ -310,10 +318,12 @@ export async function updateRowPriority(
     throw new ValidationError(`Priority must be one of: ${validPriorities.join(', ')}`);
   }
 
-  const existingRow = await findOwnedRow(gridId, rowId, userId);
-  if (!existingRow) return null;
+  const found = await findOwnedRow(gridId, rowId, userId);
+  if (!found) return null;
 
-  return prisma.$transaction(async (tx) => {
+  const { fadeEnabled } = found;
+
+  const row = await prisma.$transaction(async (tx) => {
     await tx.practiceRow.update({
       where: { id: rowId },
       data: { priority: priority as 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' },
@@ -342,11 +352,13 @@ export async function updateRowPriority(
       },
     });
   });
+
+  return { row, fadeEnabled };
 }
 
 export async function deleteRow(gridId: string, rowId: string, userId: string): Promise<boolean> {
-  const existingRow = await findOwnedRow(gridId, rowId, userId);
-  if (!existingRow) return false;
+  const found = await findOwnedRow(gridId, rowId, userId);
+  if (!found) return false;
 
   const now = new Date();
 

--- a/src/views/grid.ts
+++ b/src/views/grid.ts
@@ -31,8 +31,8 @@ export function formatGrid(grid: GridRecord) {
   };
 }
 
-export function formatGridDetail(grid: GridDetailRecord) {
-  const rows = grid.practiceRows.map((row) => formatRow(row, grid.fadeEnabled));
+export function formatGridDetail(grid: GridDetailRecord, now: Date) {
+  const rows = grid.practiceRows.map((row) => formatRow(row, grid.fadeEnabled, now));
 
   const allCellStates: CellWithEffectiveState[] = rows.flatMap((row) =>
     row.cells.map((cell) => ({ effectiveState: cell.freshnessState }))

--- a/src/views/grid.ts
+++ b/src/views/grid.ts
@@ -1,4 +1,9 @@
 import { formatRow } from '@/views/row';
+import {
+  calculateCompletionPercentage,
+  calculateFreshnessSummary,
+  type CellWithEffectiveState,
+} from '@/models/freshness';
 
 interface GridRecord {
   id: string;
@@ -27,9 +32,17 @@ export function formatGrid(grid: GridRecord) {
 }
 
 export function formatGridDetail(grid: GridDetailRecord) {
+  const rows = grid.practiceRows.map((row) => formatRow(row, grid.fadeEnabled));
+
+  const allCellStates: CellWithEffectiveState[] = rows.flatMap((row) =>
+    row.cells.map((cell) => ({ effectiveState: cell.freshnessState }))
+  );
+
   return {
     ...formatGrid(grid),
-    rows: grid.practiceRows.map(formatRow),
+    completionPercentage: calculateCompletionPercentage(allCellStates, grid.fadeEnabled),
+    freshnessSummary: calculateFreshnessSummary(allCellStates),
+    rows,
   };
 }
 

--- a/src/views/row.ts
+++ b/src/views/row.ts
@@ -1,4 +1,13 @@
 import { formatPieceInline } from '@/views/piece';
+import {
+  calculateFreshnessState,
+  isShielded,
+  effectiveFreshnessState,
+  calculateCompletionPercentage,
+  calculateFreshnessSummary,
+  type CellWithState,
+  type FreshnessState,
+} from '@/models/freshness';
 
 interface RowPiece {
   id: string;
@@ -50,6 +59,20 @@ interface RowRecord {
   practiceCells: RowCell[];
 }
 
+interface CellFreshnessData {
+  freshnessState: FreshnessState;
+  lastCompletionDate: string | null;
+  isShielded: boolean;
+}
+
+interface CellWithSiblings extends RowCell {
+  practiceRow: {
+    targetTempo: number;
+    practiceGrid: { fadeEnabled: boolean };
+    practiceCells: (RowCell & { completions: RowCompletion[] })[];
+  };
+}
+
 function formatCompletion(completion: RowCompletion) {
   return {
     id: completion.id,
@@ -58,20 +81,66 @@ function formatCompletion(completion: RowCompletion) {
   };
 }
 
-function formatCell(cell: RowCell, rowTargetTempo: number) {
+function formatCell(cell: RowCell, rowTargetTempo: number, freshness: CellFreshnessData) {
   return {
     id: cell.id,
     stepNumber: cell.stepNumber,
     targetTempoPercentage: cell.targetTempoPercentage,
     targetTempoBpm: Math.round(cell.targetTempoPercentage * rowTargetTempo),
     freshnessIntervalDays: cell.freshnessIntervalDays,
+    freshnessState: freshness.freshnessState,
+    lastCompletionDate: freshness.lastCompletionDate,
+    isShielded: freshness.isShielded,
     createdAt: cell.createdAt.toISOString(),
     updatedAt: cell.updatedAt.toISOString(),
     completions: cell.completions.map(formatCompletion),
   };
 }
 
-export function formatRow(row: RowRecord) {
+export function formatRow(row: RowRecord, fadeEnabled: boolean) {
+  const now = new Date();
+
+  // Sort cells by targetTempoPercentage ascending for shielding
+  const sortedCells = [...row.practiceCells]
+    .sort((a, b) => a.targetTempoPercentage - b.targetTempoPercentage);
+
+  // Compute raw states for all cells
+  const cellStates: CellWithState[] = sortedCells.map((cell) => {
+    const lastCompletion = cell.completions.length > 0
+      ? cell.completions[cell.completions.length - 1].completionDate
+      : null;
+    const rawState = calculateFreshnessState(lastCompletion, cell.freshnessIntervalDays, now);
+    return {
+      rawState,
+      hasCompletions: cell.completions.length > 0,
+    };
+  });
+
+  // Compute effective states (shielding + fade)
+  const effectiveStates = cellStates.map((_, index) => {
+    const shielded = isShielded(index, cellStates, fadeEnabled);
+    return effectiveFreshnessState(cellStates[index].rawState, shielded, fadeEnabled);
+  });
+
+  // Format cells with freshness data
+  const cells = sortedCells.map((cell, index) => {
+    const lastCompletion = cell.completions.length > 0
+      ? cell.completions[cell.completions.length - 1].completionDate
+      : null;
+    const shielded = isShielded(index, cellStates, fadeEnabled);
+    const freshnessData: CellFreshnessData = {
+      freshnessState: effectiveStates[index],
+      lastCompletionDate: lastCompletion
+        ? lastCompletion.toISOString().slice(0, 10)
+        : null,
+      isShielded: shielded,
+    };
+    return formatCell(cell, row.targetTempo, freshnessData);
+  });
+
+  // Row-level aggregates
+  const cellEffective = effectiveStates.map((es) => ({ effectiveState: es }));
+
   return {
     id: row.id,
     sortOrder: row.sortOrder,
@@ -82,8 +151,55 @@ export function formatRow(row: RowRecord) {
     targetTempo: row.targetTempo,
     steps: row.steps,
     priority: row.priority,
+    completionPercentage: calculateCompletionPercentage(cellEffective, fadeEnabled),
+    freshnessSummary: calculateFreshnessSummary(cellEffective),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
-    cells: row.practiceCells.map((cell) => formatCell(cell, row.targetTempo)),
+    cells,
+  };
+}
+
+/**
+ * Format a single cell response for cell action endpoints (complete/undo/reset).
+ * Must use ALL sibling cells to compute shielding correctly.
+ */
+export function formatCellResponse(cell: CellWithSiblings) {
+  const fadeEnabled = cell.practiceRow.practiceGrid.fadeEnabled;
+  const targetTempo = cell.practiceRow.targetTempo;
+  const now = new Date();
+
+  const siblings = [...cell.practiceRow.practiceCells]
+    .sort((a, b) => a.targetTempoPercentage - b.targetTempoPercentage);
+
+  const cellStates: CellWithState[] = siblings.map((sib) => {
+    const lastCompletion = sib.completions.length > 0
+      ? sib.completions[sib.completions.length - 1].completionDate
+      : null;
+    return {
+      rawState: calculateFreshnessState(lastCompletion, sib.freshnessIntervalDays, now),
+      hasCompletions: sib.completions.length > 0,
+    };
+  });
+
+  const cellIndex = siblings.findIndex((sib) => sib.id === cell.id);
+  const shielded = isShielded(cellIndex, cellStates, fadeEnabled);
+  const effState = effectiveFreshnessState(cellStates[cellIndex].rawState, shielded, fadeEnabled);
+
+  const lastCompletion = cell.completions.length > 0
+    ? cell.completions[cell.completions.length - 1].completionDate
+    : null;
+
+  return {
+    id: cell.id,
+    stepNumber: cell.stepNumber,
+    targetTempoPercentage: cell.targetTempoPercentage,
+    targetTempoBpm: Math.round(cell.targetTempoPercentage * targetTempo),
+    freshnessIntervalDays: cell.freshnessIntervalDays,
+    freshnessState: effState,
+    lastCompletionDate: lastCompletion ? lastCompletion.toISOString().slice(0, 10) : null,
+    isShielded: shielded,
+    createdAt: cell.createdAt.toISOString(),
+    updatedAt: cell.updatedAt.toISOString(),
+    completions: cell.completions.map(formatCompletion),
   };
 }

--- a/src/views/row.ts
+++ b/src/views/row.ts
@@ -76,7 +76,7 @@ interface CellWithSiblings extends RowCell {
 function formatCompletion(completion: RowCompletion) {
   return {
     id: completion.id,
-    completionDate: completion.completionDate.toISOString(),
+    completionDate: completion.completionDate.toISOString().slice(0, 10),
     createdAt: completion.createdAt.toISOString(),
   };
 }

--- a/src/views/row.ts
+++ b/src/views/row.ts
@@ -97,8 +97,7 @@ function formatCell(cell: RowCell, rowTargetTempo: number, freshness: CellFreshn
   };
 }
 
-export function formatRow(row: RowRecord, fadeEnabled: boolean) {
-  const now = new Date();
+export function formatRow(row: RowRecord, fadeEnabled: boolean, now: Date) {
 
   // Sort cells by targetTempoPercentage ascending for shielding
   const sortedCells = [...row.practiceCells]
@@ -163,10 +162,9 @@ export function formatRow(row: RowRecord, fadeEnabled: boolean) {
  * Format a single cell response for cell action endpoints (complete/undo/reset).
  * Must use ALL sibling cells to compute shielding correctly.
  */
-export function formatCellResponse(cell: CellWithSiblings) {
+export function formatCellResponse(cell: CellWithSiblings, now: Date) {
   const fadeEnabled = cell.practiceRow.practiceGrid.fadeEnabled;
   const targetTempo = cell.practiceRow.targetTempo;
-  const now = new Date();
 
   const siblings = [...cell.practiceRow.practiceCells]
     .sort((a, b) => a.targetTempoPercentage - b.targetTempoPercentage);

--- a/tests/integration/api/completions.test.ts
+++ b/tests/integration/api/completions.test.ts
@@ -6,7 +6,7 @@ import {
   undoCompletion,
   resetCell,
 } from '@/controllers/cell';
-import { updateFade } from '@/controllers/grid';
+import { updateFade, getGrid } from '@/controllers/grid';
 
 const prisma = getTestPrisma();
 
@@ -462,5 +462,292 @@ describe('Grid API — Update Fade Auth failure', () => {
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+});
+
+// ─── Interval Progression ────────────────────────────────────────────────────
+
+describe('Cell API — Interval Progression', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('complete fresh cell: interval doubles (1 → 2)', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+    const cell = cells[0];
+
+    // First completion: interval becomes 1 (incomplete → 1)
+    const first = await completeCell(grid.id, row.id, cell.id);
+    expect(first.status).toBe(201);
+    const firstBody = await first.json();
+    expect(firstBody.freshnessIntervalDays).toBe(1);
+
+    // Backdate completion to yesterday so we can complete again today
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const yesterdayUTC = new Date(Date.UTC(
+      yesterday.getUTCFullYear(), yesterday.getUTCMonth(), yesterday.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cell.id },
+      data: { completionDate: yesterdayUTC },
+    });
+
+    // Second completion: cell is fresh (daysSince=1 <= interval*0.5? No, 1 > 0.5, but <= 1 = aging)
+    // Actually with interval=1: daysSince=1 <= 1*0.5=0.5? No. daysSince=1 <= 1? Yes → aging.
+    // Aging → interval doubles: 1 * 2 = 2
+    const second = await completeCell(grid.id, row.id, cell.id);
+    expect(second.status).toBe(201);
+    const secondBody = await second.json();
+    expect(secondBody.freshnessIntervalDays).toBe(2);
+  });
+
+  it('complete stale cell: interval resets to 1', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+    const cell = cells[0];
+
+    // First completion: interval becomes 1
+    await completeCell(grid.id, row.id, cell.id);
+
+    // Directly set interval to 4 via DB (simulating built-up interval)
+    await prisma.practiceCell.update({
+      where: { id: cell.id },
+      data: { freshnessIntervalDays: 4 },
+    });
+
+    // Backdate completion to 5 days ago to make cell stale
+    // (daysSince=5 > interval=4 but <= interval*2=8 → stale)
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+    const fiveDaysAgoUTC = new Date(Date.UTC(
+      fiveDaysAgo.getUTCFullYear(), fiveDaysAgo.getUTCMonth(), fiveDaysAgo.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cell.id, deletedAt: null },
+      data: { completionDate: fiveDaysAgoUTC },
+    });
+
+    // Complete again: stale → interval resets to 1
+    const res = await completeCell(grid.id, row.id, cell.id);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.freshnessIntervalDays).toBe(1);
+  });
+
+  it('complete a shielded cell: interval uses raw state (stale), not effective state (fresh)', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    // Create 2 cells: cell[0] (lower tempo) and cell[1] (higher tempo)
+    const { grid, row, cells } = await createGridWithCells(user.id, 2);
+
+    // Complete both cells
+    await completeCell(grid.id, row.id, cells[0].id);
+    await completeCell(grid.id, row.id, cells[1].id);
+
+    // Set cell[0]'s interval to 4 (simulating built-up interval)
+    await prisma.practiceCell.update({
+      where: { id: cells[0].id },
+      data: { freshnessIntervalDays: 4 },
+    });
+
+    // Backdate cell[0]'s completion to 5 days ago → raw state = stale
+    // (daysSince=5 > interval=4 but <= interval*2=8 → stale)
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+    const fiveDaysAgoUTC = new Date(Date.UTC(
+      fiveDaysAgo.getUTCFullYear(), fiveDaysAgo.getUTCMonth(), fiveDaysAgo.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cells[0].id, deletedAt: null },
+      data: { completionDate: fiveDaysAgoUTC },
+    });
+
+    // Cell[0] is shielded (cell[1] above it is fresh, NOT decayed),
+    // but raw state is stale (daysSince=5 > interval=4).
+    // Verify via grid detail that cell[0] is shielded with effective state 'fresh'
+    const gridRes = await getGrid(grid.id);
+    const gridBody = await gridRes.json();
+    const rowData = gridBody.rows[0];
+    expect(rowData.cells[0].isShielded).toBe(true);
+    expect(rowData.cells[0].freshnessState).toBe('fresh'); // effective (shielded)
+
+    // Now complete the shielded cell: should use RAW state (stale) → interval resets to 1
+    const res = await completeCell(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.freshnessIntervalDays).toBe(1); // reset, not doubled
+  });
+});
+
+// ─── Fade Toggle Effects ─────────────────────────────────────────────────────
+
+describe('Cell API — Fade Toggle Effects', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  function makeFadeRequest(gridId: string, body: unknown): NextRequest {
+    return new NextRequest(`http://localhost:3000/api/grids/${gridId}/fade`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('fade OFF: all completed cells = 100% completion', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 3);
+
+    // Complete all 3 cells
+    for (const cell of cells) {
+      await completeCell(grid.id, row.id, cell.id);
+    }
+
+    // Turn fade off
+    const fadeRes = await updateFade(grid.id, makeFadeRequest(grid.id, { fadeEnabled: false }));
+    const fadeBody = await fadeRes.json();
+    expect(fadeBody.fadeEnabled).toBe(false);
+    expect(fadeBody.completionPercentage).toBe(100);
+
+    // All cells should show fresh state when fade is off
+    const rowData = fadeBody.rows[0];
+    for (const cell of rowData.cells) {
+      expect(cell.freshnessState).toBe('fresh');
+    }
+  });
+
+  it('fade ON: decayed cells excluded from completion percentage', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 2);
+
+    // Complete both cells
+    await completeCell(grid.id, row.id, cells[0].id);
+    await completeCell(grid.id, row.id, cells[1].id);
+
+    // Backdate both to make them decayed: interval=1, need daysSince > 2
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+    const fiveDaysAgoUTC = new Date(Date.UTC(
+      fiveDaysAgo.getUTCFullYear(), fiveDaysAgo.getUTCMonth(), fiveDaysAgo.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: { in: [cells[0].id, cells[1].id] } },
+      data: { completionDate: fiveDaysAgoUTC },
+    });
+
+    // Grid has fade ON by default
+    const gridRes = await getGrid(grid.id);
+    const gridBody = await gridRes.json();
+    expect(gridBody.fadeEnabled).toBe(true);
+    // Both decayed → 0% (decayed cells excluded from completion percentage)
+    expect(gridBody.completionPercentage).toBe(0);
+  });
+});
+
+// ─── UTC Date-Boundary Tests ─────────────────────────────────────────────────
+
+describe('Cell API — UTC Date Boundaries', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('backdate completion to yesterday, complete again today → 201', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    // Complete today
+    const first = await completeCell(grid.id, row.id, cells[0].id);
+    expect(first.status).toBe(201);
+
+    // Backdate to yesterday
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const yesterdayUTC = new Date(Date.UTC(
+      yesterday.getUTCFullYear(), yesterday.getUTCMonth(), yesterday.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cells[0].id },
+      data: { completionDate: yesterdayUTC },
+    });
+
+    // Complete again today — different UTC date, should succeed
+    const second = await completeCell(grid.id, row.id, cells[0].id);
+    expect(second.status).toBe(201);
+  });
+
+  it('completionDate in response is YYYY-MM-DD format', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await completeCell(grid.id, row.id, cells[0].id);
+    const body = await res.json();
+
+    // lastCompletionDate should be YYYY-MM-DD
+    expect(body.lastCompletionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    // Completions array also uses YYYY-MM-DD
+    expect(body.completions[0].completionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('backdate to same UTC date, attempt again → 409', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    // Complete today
+    await completeCell(grid.id, row.id, cells[0].id);
+
+    // "Backdate" to same UTC date (today) — this is a no-op but simulates
+    // a scenario where the completion is still on today's date
+    const todayUTC = new Date(Date.UTC(
+      new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cells[0].id },
+      data: { completionDate: todayUTC },
+    });
+
+    // Attempt again → 409 (same UTC date)
+    const second = await completeCell(grid.id, row.id, cells[0].id);
+    expect(second.status).toBe(409);
+  });
+});
+
+// ─── Concurrent Same-Day Completion ──────────────────────────────────────────
+
+describe('Cell API — Concurrent Same-Day Completion', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('Promise.all: exactly one 201 and one 409', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const [res1, res2] = await Promise.all([
+      completeCell(grid.id, row.id, cells[0].id),
+      completeCell(grid.id, row.id, cells[0].id),
+    ]);
+
+    const statuses = [res1.status, res2.status].sort();
+    expect(statuses).toEqual([201, 409]);
   });
 });

--- a/tests/integration/api/completions.test.ts
+++ b/tests/integration/api/completions.test.ts
@@ -751,3 +751,63 @@ describe('Cell API — Concurrent Same-Day Completion', () => {
     expect(statuses).toEqual([201, 409]);
   });
 });
+
+// ─── Cascading Fade ──────────────────────────────────────────────────────────
+
+describe('Cell API — Cascading Fade', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('fades highest cell first, then cascades down', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 6);
+
+    // Complete all 6 cells
+    for (const cell of cells) {
+      await completeCell(grid.id, row.id, cell.id);
+    }
+
+    // Fetch grid detail — verify only highest cell (index 5) is unshielded
+    let gridRes = await getGrid(grid.id);
+    let gridBody = await gridRes.json();
+    let rowData = gridBody.rows[0];
+    expect(rowData.cells[5].isShielded).toBe(false); // highest completed = unshielded
+    expect(rowData.cells[4].isShielded).toBe(true);  // shielded by cell 5
+    expect(rowData.cells[3].isShielded).toBe(true);
+    expect(rowData.cells[2].isShielded).toBe(true);
+    expect(rowData.cells[1].isShielded).toBe(true);
+    expect(rowData.cells[0].isShielded).toBe(true);
+
+    // Backdate highest cell's completion to make it decayed
+    // interval=1, decayed = daysSince > 2. Set completion to 5 days ago.
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+    const fiveDaysAgoUTC = new Date(Date.UTC(
+      fiveDaysAgo.getUTCFullYear(), fiveDaysAgo.getUTCMonth(), fiveDaysAgo.getUTCDate(),
+    ));
+    await prisma.practiceCellCompletion.updateMany({
+      where: { practiceCellId: cells[5].id, deletedAt: null },
+      data: { completionDate: fiveDaysAgoUTC },
+    });
+
+    // Re-fetch — cell 5 is decayed, cell 4 is now unshielded, rest still shielded
+    gridRes = await getGrid(grid.id);
+    gridBody = await gridRes.json();
+    rowData = gridBody.rows[0];
+    expect(rowData.cells[5].freshnessState).toBe('decayed');
+    expect(rowData.cells[5].isShielded).toBe(false); // highest, never shielded
+    expect(rowData.cells[4].isShielded).toBe(false); // shield has fallen (cell 5 decayed)
+    expect(rowData.cells[3].isShielded).toBe(true);  // still shielded by cell 4
+    expect(rowData.cells[2].isShielded).toBe(true);
+    expect(rowData.cells[1].isShielded).toBe(true);
+    expect(rowData.cells[0].isShielded).toBe(true);
+
+    // Verify completion percentage changed: with fade ON, decayed cells excluded
+    // 5 fresh/aging/stale + 1 decayed = 5/6 * 100 = 83.33%
+    // But cell 4 is now unshielded and fresh (completed today), so still counts
+    expect(gridBody.completionPercentage).toBeCloseTo(500 / 6, 1);
+  });
+});

--- a/tests/integration/api/completions.test.ts
+++ b/tests/integration/api/completions.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getTestPrisma } from '../../helpers/db';
+import {
+  completeCell,
+  undoCompletion,
+  resetCell,
+} from '@/controllers/cell';
+import { updateFade } from '@/controllers/grid';
+
+const prisma = getTestPrisma();
+
+async function createSeedUser() {
+  return prisma.user.upsert({
+    where: { email: 'dev-placeholder@tessitura.local' },
+    update: {},
+    create: {
+      email: 'dev-placeholder@tessitura.local',
+      passwordHash: 'not-a-real-hash',
+      displayName: 'Dev User',
+      instruments: [],
+    },
+  });
+}
+
+async function createGridWithCells(userId: string, steps = 5) {
+  const grid = await prisma.practiceGrid.create({
+    data: { userId, name: 'Test Grid', fadeEnabled: true },
+  });
+  const row = await prisma.practiceRow.create({
+    data: {
+      practiceGridId: grid.id,
+      sortOrder: 0,
+      startMeasure: 1,
+      endMeasure: 4,
+      targetTempo: 120,
+      steps,
+    },
+  });
+  const percentages = Array.from({ length: steps }, (_, i) =>
+    steps === 1 ? 1.0 : 0.4 + (0.6 * i) / (steps - 1),
+  );
+  await prisma.practiceCell.createMany({
+    data: percentages.map((p, i) => ({
+      practiceRowId: row.id,
+      stepNumber: i,
+      targetTempoPercentage: p,
+    })),
+  });
+  const cells = await prisma.practiceCell.findMany({
+    where: { practiceRowId: row.id },
+    orderBy: { stepNumber: 'asc' },
+  });
+  return { grid, row, cells };
+}
+
+// ─── Auth failure tests ──────────────────────────────────────────────────────
+
+describe('Cell API — Auth failure (placeholder auth, pre-M1.8)', () => {
+  const validId = '00000000-0000-0000-0000-000000000000';
+
+  it('returns 401 when auth fails on completeCell', async () => {
+    const res = await completeCell(validId, validId, validId);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+
+  it('returns 401 when auth fails on undoCompletion', async () => {
+    const res = await undoCompletion(validId, validId, validId);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+
+  it('returns 401 when auth fails on resetCell', async () => {
+    const res = await resetCell(validId, validId, validId);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+});
+
+// ─── Validation tests ─────────────────────────────────────────────────────────
+
+describe('Cell API — Validation', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('returns 400 for malformed grid ID on completeCell', async () => {
+    const res = await completeCell('not-a-uuid', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for malformed row ID on undoCompletion', async () => {
+    const res = await undoCompletion('00000000-0000-0000-0000-000000000000', 'bad', '00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for malformed cell ID on resetCell', async () => {
+    const res = await resetCell('00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'bad');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ─── Complete Cell ────────────────────────────────────────────────────────────
+
+describe('Cell API — Complete', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('returns 201 and creates a completion with freshnessState=fresh, interval=1', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+    const cell = cells[0];
+
+    const res = await completeCell(grid.id, row.id, cell.id);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.id).toBe(cell.id);
+    expect(body.freshnessState).toBe('fresh');
+    expect(body.freshnessIntervalDays).toBe(1);
+    expect(body.completions).toHaveLength(1);
+    expect(body.lastCompletionDate).toBeDefined();
+  });
+
+  it('returns 409 when completing same cell same day', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const first = await completeCell(grid.id, row.id, cells[0].id);
+    expect(first.status).toBe(201);
+
+    const second = await completeCell(grid.id, row.id, cells[0].id);
+    expect(second.status).toBe(409);
+    const body = await second.json();
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('returns 404 for non-existent cell', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row } = await createGridWithCells(user.id, 1);
+
+    const res = await completeCell(grid.id, row.id, '00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for non-existent row', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await completeCell(grid.id, '00000000-0000-0000-0000-000000000000', cells[0].id);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for non-existent grid', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { row, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await completeCell('00000000-0000-0000-0000-000000000000', row.id, cells[0].id);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for grid owned by different user', async () => {
+    const otherUser = await prisma.user.create({
+      data: {
+        email: `other-${Date.now()}@example.com`,
+        passwordHash: 'hash',
+        displayName: 'Other',
+        instruments: [],
+      },
+    });
+    const { grid, row, cells } = await createGridWithCells(otherUser.id, 1);
+
+    // Seed user (auth placeholder) tries to access other user's grid
+    const res = await completeCell(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(404);
+  });
+
+  it('response includes targetTempoBpm computed from percentage and row tempo', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await completeCell(grid.id, row.id, cells[0].id);
+    const body = await res.json();
+    // 1.0 * 120 = 120
+    expect(body.targetTempoBpm).toBe(120);
+  });
+});
+
+// ─── Undo Completion ──────────────────────────────────────────────────────────
+
+describe('Cell API — Undo', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('returns 200 and soft-deletes most recent completion', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    await completeCell(grid.id, row.id, cells[0].id);
+    const res = await undoCompletion(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.completions).toHaveLength(0);
+  });
+
+  it('returns 409 when no completions to undo', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await undoCompletion(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('resets interval to 1 when no completions remain', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    await completeCell(grid.id, row.id, cells[0].id);
+    const res = await undoCompletion(grid.id, row.id, cells[0].id);
+    const body = await res.json();
+    expect(body.freshnessIntervalDays).toBe(1);
+  });
+
+  it('undo then re-complete same day returns 201 (un-soft-deletes)', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    // Complete
+    const first = await completeCell(grid.id, row.id, cells[0].id);
+    expect(first.status).toBe(201);
+
+    // Undo
+    const undo = await undoCompletion(grid.id, row.id, cells[0].id);
+    expect(undo.status).toBe(200);
+
+    // Re-complete (should un-soft-delete, not conflict)
+    const second = await completeCell(grid.id, row.id, cells[0].id);
+    expect(second.status).toBe(201);
+
+    const body = await second.json();
+    expect(body.completions).toHaveLength(1);
+  });
+
+  it('returns 404 for non-existent cell', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row } = await createGridWithCells(user.id, 1);
+
+    const res = await undoCompletion(grid.id, row.id, '00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Reset Cell ───────────────────────────────────────────────────────────────
+
+describe('Cell API — Reset', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('returns 200 and sets interval to 1', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    // Complete to create a completion and potentially bump interval
+    await completeCell(grid.id, row.id, cells[0].id);
+
+    const res = await resetCell(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.freshnessIntervalDays).toBe(1);
+  });
+
+  it('returns 409 when no completions to reset', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    const res = await resetCell(grid.id, row.id, cells[0].id);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('keeps all completion records intact after reset', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    await completeCell(grid.id, row.id, cells[0].id);
+    const res = await resetCell(grid.id, row.id, cells[0].id);
+    const body = await res.json();
+    expect(body.completions).toHaveLength(1);
+  });
+
+  it('returns 404 for non-existent cell', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row } = await createGridWithCells(user.id, 1);
+
+    const res = await resetCell(grid.id, row.id, '00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Update Fade ──────────────────────────────────────────────────────────────
+
+describe('Grid API — Update Fade', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  function makeFadeRequest(gridId: string, body: unknown): NextRequest {
+    return new NextRequest(`http://localhost:3000/api/grids/${gridId}/fade`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('returns 200 and updates fadeEnabled to false', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: user.id, name: 'Fade Grid', fadeEnabled: true },
+    });
+
+    const res = await updateFade(grid.id, makeFadeRequest(grid.id, { fadeEnabled: false }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.fadeEnabled).toBe(false);
+  });
+
+  it('returns 200 and updates fadeEnabled to true', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: user.id, name: 'Fade Grid', fadeEnabled: false },
+    });
+
+    const res = await updateFade(grid.id, makeFadeRequest(grid.id, { fadeEnabled: true }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.fadeEnabled).toBe(true);
+  });
+
+  it('returns 400 when fadeEnabled is not a boolean', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: user.id, name: 'Fade Grid' },
+    });
+
+    const res = await updateFade(grid.id, makeFadeRequest(grid.id, { fadeEnabled: 'yes' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: user.id, name: 'Fade Grid' },
+    });
+
+    const res = await updateFade(grid.id, makeFadeRequest(grid.id, {}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for malformed grid ID', async () => {
+    const res = await updateFade('not-a-uuid', makeFadeRequest('not-a-uuid', { fadeEnabled: true }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 for non-existent grid', async () => {
+    const res = await updateFade(
+      '00000000-0000-0000-0000-000000000000',
+      makeFadeRequest('00000000-0000-0000-0000-000000000000', { fadeEnabled: true }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for grid owned by different user', async () => {
+    const otherUser = await prisma.user.create({
+      data: {
+        email: `other-${Date.now()}@example.com`,
+        passwordHash: 'hash',
+        displayName: 'Other',
+        instruments: [],
+      },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Other Grid' },
+    });
+
+    const res = await updateFade(grid.id, makeFadeRequest(grid.id, { fadeEnabled: false }));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Auth failure for updateFade ──────────────────────────────────────────────
+
+describe('Grid API — Update Fade Auth failure', () => {
+  it('returns 401 when auth fails on updateFade', async () => {
+    const req = new NextRequest('http://localhost:3000/api/grids/00000000-0000-0000-0000-000000000000/fade', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fadeEnabled: true }),
+    });
+    const res = await updateFade('00000000-0000-0000-0000-000000000000', req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+});

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -7,6 +7,7 @@ import {
   getGrid,
   deleteGrid,
 } from '@/controllers/grid';
+import { completeCell } from '@/controllers/cell';
 
 const prisma = getTestPrisma();
 
@@ -655,5 +656,116 @@ describe('Grid API — Delete', () => {
     const afterRes = await listGrids();
     const afterBody = await afterRes.json();
     expect(afterBody).toHaveLength(0);
+  });
+});
+
+// ─── Grid Detail — Freshness Fields ─────────────────────────────────────────
+
+describe('Grid API — Detail Freshness Fields', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  async function createGridWithCells(userId: string, steps: number) {
+    const grid = await prisma.practiceGrid.create({
+      data: { userId, name: 'Freshness Grid', fadeEnabled: true },
+    });
+    const row = await prisma.practiceRow.create({
+      data: {
+        practiceGridId: grid.id,
+        sortOrder: 0,
+        startMeasure: 1,
+        endMeasure: 4,
+        targetTempo: 120,
+        steps,
+      },
+    });
+    const percentages = Array.from({ length: steps }, (_, i) =>
+      steps === 1 ? 1.0 : 0.4 + (0.6 * i) / (steps - 1),
+    );
+    await prisma.practiceCell.createMany({
+      data: percentages.map((p, i) => ({
+        practiceRowId: row.id,
+        stepNumber: i,
+        targetTempoPercentage: p,
+      })),
+    });
+    const cells = await prisma.practiceCell.findMany({
+      where: { practiceRowId: row.id },
+      orderBy: { stepNumber: 'asc' },
+    });
+    return { grid, row, cells };
+  }
+
+  it('grid detail includes completionPercentage and freshnessSummary', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 3);
+
+    // Complete 1 of 3 cells
+    await completeCell(grid.id, row.id, cells[0].id);
+
+    const res = await getGrid(grid.id);
+    const body = await res.json();
+
+    expect(body).toHaveProperty('completionPercentage');
+    expect(body).toHaveProperty('freshnessSummary');
+    expect(typeof body.completionPercentage).toBe('number');
+    expect(body.freshnessSummary).toHaveProperty('fresh');
+    expect(body.freshnessSummary).toHaveProperty('aging');
+    expect(body.freshnessSummary).toHaveProperty('stale');
+    expect(body.freshnessSummary).toHaveProperty('decayed');
+    expect(body.freshnessSummary).toHaveProperty('incomplete');
+
+    // 1 fresh, 2 incomplete → completionPercentage = 1/3 * 100
+    // With fade ON: fresh+aging+stale count → 1/3 * 100
+    expect(body.freshnessSummary.fresh).toBe(1);
+    expect(body.freshnessSummary.incomplete).toBe(2);
+    expect(body.completionPercentage).toBeCloseTo(100 / 3, 1);
+  });
+
+  it('row-level completionPercentage and freshnessSummary in grid detail', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 2);
+
+    // Complete 1 of 2 cells
+    await completeCell(grid.id, row.id, cells[0].id);
+
+    const res = await getGrid(grid.id);
+    const body = await res.json();
+
+    const rowData = body.rows[0];
+    expect(rowData).toHaveProperty('completionPercentage');
+    expect(rowData).toHaveProperty('freshnessSummary');
+    expect(rowData.completionPercentage).toBe(50);
+    expect(rowData.freshnessSummary.fresh).toBe(1);
+    expect(rowData.freshnessSummary.incomplete).toBe(1);
+  });
+
+  it('cell response includes freshnessState, lastCompletionDate, isShielded', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const { grid, row, cells } = await createGridWithCells(user.id, 1);
+
+    // Before completion: incomplete
+    const beforeRes = await getGrid(grid.id);
+    const beforeBody = await beforeRes.json();
+    const beforeCell = beforeBody.rows[0].cells[0];
+    expect(beforeCell.freshnessState).toBe('incomplete');
+    expect(beforeCell.lastCompletionDate).toBeNull();
+    expect(beforeCell.isShielded).toBe(false);
+
+    // After completion: fresh
+    await completeCell(grid.id, row.id, cells[0].id);
+    const afterRes = await getGrid(grid.id);
+    const afterBody = await afterRes.json();
+    const afterCell = afterBody.rows[0].cells[0];
+    expect(afterCell.freshnessState).toBe('fresh');
+    expect(afterCell.lastCompletionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof afterCell.isShielded).toBe('boolean');
   });
 });

--- a/tests/integration/models/user.test.ts
+++ b/tests/integration/models/user.test.ts
@@ -87,7 +87,6 @@ describe('User model', () => {
     expect(user.emailVerified).toBe(false);
     expect(user.timezone).toBe('UTC');
     expect(user.defaultFadeEnabled).toBe(true);
-    expect(user.freshnessResetStrategy).toBe('FULL');
     expect(user.deletedAt).toBeNull();
   });
 

--- a/tests/unit/controllers/error-handling.test.ts
+++ b/tests/unit/controllers/error-handling.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/models/grid', () => ({
   listGrids: vi.fn(() => { throw new Error('db exploded'); }),
   getGridById: vi.fn(() => { throw new Error('db exploded'); }),
   deleteGrid: vi.fn(() => { throw new Error('db exploded'); }),
+  updateGridFade: vi.fn(() => { throw new Error('db exploded'); }),
 }));
 
 vi.mock('@/models/piece', () => ({
@@ -33,6 +34,12 @@ vi.mock('@/models/row', () => ({
   updateRow: vi.fn(() => { throw new Error('db exploded'); }),
   updateRowPriority: vi.fn(() => { throw new Error('db exploded'); }),
   deleteRow: vi.fn(() => { throw new Error('db exploded'); }),
+}));
+
+vi.mock('@/models/cell', () => ({
+  completeCell: vi.fn(() => { throw new Error('db exploded'); }),
+  undoCompletion: vi.fn(() => { throw new Error('db exploded'); }),
+  resetCell: vi.fn(() => { throw new Error('db exploded'); }),
 }));
 
 function jsonRequest(method: string, body: unknown): NextRequest {
@@ -80,6 +87,15 @@ describe('Grid controller — unexpected errors → 500', () => {
   it('deleteGrid returns 500 on unexpected error', async () => {
     const { deleteGrid } = await import('@/controllers/grid');
     const res = await deleteGrid(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('updateFade returns 500 on unexpected error', async () => {
+    const { updateFade } = await import('@/controllers/grid');
+    const req = jsonRequest('PUT', { fadeEnabled: true });
+    const res = await updateFade(VALID_UUID, req);
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.error.code).toBe('INTERNAL_ERROR');
@@ -167,6 +183,34 @@ describe('Row controller — unexpected errors → 500', () => {
   it('deleteRow returns 500 on unexpected error', async () => {
     const { deleteRow } = await import('@/controllers/row');
     const res = await deleteRow(VALID_UUID, VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── Cell controller ──────────────────────────────────────────────────────────
+
+describe('Cell controller — unexpected errors → 500', () => {
+  it('completeCell returns 500 on unexpected error', async () => {
+    const { completeCell } = await import('@/controllers/cell');
+    const res = await completeCell(VALID_UUID, VALID_UUID, VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('undoCompletion returns 500 on unexpected error', async () => {
+    const { undoCompletion } = await import('@/controllers/cell');
+    const res = await undoCompletion(VALID_UUID, VALID_UUID, VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('resetCell returns 500 on unexpected error', async () => {
+    const { resetCell } = await import('@/controllers/cell');
+    const res = await resetCell(VALID_UUID, VALID_UUID, VALID_UUID);
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.error.code).toBe('INTERNAL_ERROR');

--- a/tests/unit/models/clock-consistency.test.ts
+++ b/tests/unit/models/clock-consistency.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { dateOnlyUTC } from '@/models/cell';
+import { calculateFreshnessState } from '@/models/freshness';
+
+describe('Clock consistency — dateOnlyUTC', () => {
+  it('truncates time portion, preserving UTC date', () => {
+    const now = new Date('2026-03-18T23:59:59.999Z');
+    const result = dateOnlyUTC(now);
+    expect(result.toISOString()).toBe('2026-03-18T00:00:00.000Z');
+  });
+
+  it('derives from the passed-in now, not the system clock', () => {
+    // Pass a date far in the future — if it called new Date() internally,
+    // the result would be "today" instead.
+    const future = new Date('2030-12-25T15:30:00Z');
+    const result = dateOnlyUTC(future);
+    expect(result.toISOString()).toBe('2030-12-25T00:00:00.000Z');
+  });
+
+  it('handles midnight exactly', () => {
+    const midnight = new Date('2026-06-01T00:00:00.000Z');
+    const result = dateOnlyUTC(midnight);
+    expect(result.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  });
+});
+
+describe('Clock consistency — single now through complete flow', () => {
+  it('completionDate and freshnessState agree on the same now value', () => {
+    // Scenario: completion was recorded at 2026-03-17T00:00:00Z with interval=2.
+    // If now = 2026-03-18T23:59:59Z (late on the 18th):
+    //   dateOnlyUTC(now) = 2026-03-18 (the completion date that would be stored)
+    //   calculateFreshnessState(completionDate=2026-03-17, interval=2, now) should be "fresh"
+    //   because daysSince = floor((18T23:59:59 - 17T00:00:00) / 86400000) = 1, and 1 <= 2*0.5 = 1 → fresh
+    //
+    // But if a DIFFERENT clock sampled a few seconds later (2026-03-19T00:00:01Z):
+    //   dateOnlyUTC(differentNow) = 2026-03-19 (different completion date!)
+    //   calculateFreshnessState(completionDate=2026-03-17, interval=2, differentNow) would be "aging"
+    //   because daysSince = 2, and 2 > 1 but <= 2 → aging
+    //
+    // This proves that using the same now for both operations prevents boundary inconsistency.
+
+    const now = new Date('2026-03-18T23:59:59.000Z');
+    const priorCompletion = new Date('2026-03-17T00:00:00.000Z');
+    const interval = 2;
+
+    const todayDate = dateOnlyUTC(now);
+    const state = calculateFreshnessState(priorCompletion, interval, now);
+
+    // Both derived from the same now
+    expect(todayDate.toISOString()).toBe('2026-03-18T00:00:00.000Z');
+    expect(state).toBe('fresh');
+
+    // With a different now (just past midnight), the result would change
+    const differentNow = new Date('2026-03-19T00:00:01.000Z');
+    const differentDate = dateOnlyUTC(differentNow);
+    const differentState = calculateFreshnessState(priorCompletion, interval, differentNow);
+
+    expect(differentDate.toISOString()).toBe('2026-03-19T00:00:00.000Z');
+    expect(differentState).toBe('aging');
+
+    // This is exactly the inconsistency that threading a single `now` prevents:
+    // without it, todayDate could come from one clock and state from another.
+  });
+});

--- a/tests/unit/models/freshness.test.ts
+++ b/tests/unit/models/freshness.test.ts
@@ -4,8 +4,11 @@ import {
   calculateNewInterval,
   isShielded,
   effectiveFreshnessState,
+  calculateCompletionPercentage,
+  calculateFreshnessSummary,
   type FreshnessState,
   type CellWithState,
+  type CellWithEffectiveState,
 } from '@/models/freshness';
 
 // ─── calculateFreshnessState ─────────────────────────────────────────────────
@@ -240,5 +243,100 @@ describe('effectiveFreshnessState', () => {
     expect(effectiveFreshnessState('aging', false, true)).toBe('aging');
     expect(effectiveFreshnessState('stale', false, true)).toBe('stale');
     expect(effectiveFreshnessState('decayed', false, true)).toBe('decayed');
+  });
+});
+
+// ─── calculateCompletionPercentage ───────────────────────────────────────────
+
+function makeEffCell(effectiveState: FreshnessState): CellWithEffectiveState {
+  return { effectiveState };
+}
+
+describe('calculateCompletionPercentage', () => {
+  it('returns 0 for empty cells array', () => {
+    expect(calculateCompletionPercentage([], true)).toBe(0);
+    expect(calculateCompletionPercentage([], false)).toBe(0);
+  });
+
+  it('returns 0 when all cells are incomplete', () => {
+    const cells = [makeEffCell('incomplete'), makeEffCell('incomplete')];
+    expect(calculateCompletionPercentage(cells, true)).toBe(0);
+    expect(calculateCompletionPercentage(cells, false)).toBe(0);
+  });
+
+  it('fade ON: fresh + aging + stale count, decayed + incomplete excluded', () => {
+    const cells = [
+      makeEffCell('fresh'),
+      makeEffCell('aging'),
+      makeEffCell('stale'),
+      makeEffCell('decayed'),
+      makeEffCell('incomplete'),
+    ];
+    expect(calculateCompletionPercentage(cells, true)).toBe(60);
+  });
+
+  it('fade OFF: all non-incomplete count', () => {
+    const cells = [
+      makeEffCell('fresh'),
+      makeEffCell('fresh'),
+      makeEffCell('fresh'),
+      makeEffCell('fresh'),
+      makeEffCell('incomplete'),
+    ];
+    expect(calculateCompletionPercentage(cells, false)).toBe(80);
+  });
+
+  it('fade OFF: non-fresh completed states also count (pure function contract)', () => {
+    const cells = [
+      makeEffCell('aging'),
+      makeEffCell('stale'),
+      makeEffCell('decayed'),
+      makeEffCell('incomplete'),
+    ];
+    expect(calculateCompletionPercentage(cells, false)).toBe(75);
+  });
+
+  it('returns 100 when all cells are fresh', () => {
+    const cells = [makeEffCell('fresh'), makeEffCell('fresh'), makeEffCell('fresh')];
+    expect(calculateCompletionPercentage(cells, true)).toBe(100);
+  });
+
+  it('returns unrounded floating-point value', () => {
+    const cells = [makeEffCell('fresh'), makeEffCell('incomplete'), makeEffCell('incomplete')];
+    const result = calculateCompletionPercentage(cells, true);
+    expect(result).toBeCloseTo(100 / 3, 10);
+  });
+});
+
+// ─── calculateFreshnessSummary ───────────────────────────────────────────────
+
+describe('calculateFreshnessSummary', () => {
+  it('counts cells by effective state', () => {
+    const cells = [
+      makeEffCell('fresh'),
+      makeEffCell('fresh'),
+      makeEffCell('aging'),
+      makeEffCell('stale'),
+      makeEffCell('decayed'),
+      makeEffCell('incomplete'),
+      makeEffCell('incomplete'),
+    ];
+    expect(calculateFreshnessSummary(cells)).toEqual({
+      fresh: 2,
+      aging: 1,
+      stale: 1,
+      decayed: 1,
+      incomplete: 2,
+    });
+  });
+
+  it('returns all zeros for empty array', () => {
+    expect(calculateFreshnessSummary([])).toEqual({
+      fresh: 0,
+      aging: 0,
+      stale: 0,
+      decayed: 0,
+      incomplete: 0,
+    });
   });
 });

--- a/tests/unit/models/freshness.test.ts
+++ b/tests/unit/models/freshness.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   calculateFreshnessState,
   calculateNewInterval,
+  isShielded,
+  effectiveFreshnessState,
   type FreshnessState,
+  type CellWithState,
 } from '@/models/freshness';
 
 // ─── calculateFreshnessState ─────────────────────────────────────────────────
@@ -112,5 +115,130 @@ describe('calculateNewInterval', () => {
       interval = calculateNewInterval(interval, 'fresh');
       expect(interval).toBe(exp);
     }
+  });
+});
+
+// ─── isShielded ──────────────────────────────────────────────────────────────
+
+function makeCell(rawState: FreshnessState, hasCompletions: boolean): CellWithState {
+  return { rawState, hasCompletions };
+}
+
+describe('isShielded', () => {
+  it('returns false when fade is disabled', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('fresh', true),
+    ];
+    expect(isShielded(0, cells, false)).toBe(false);
+  });
+
+  it('returns false for the highest completed cell (no higher neighbor)', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('aging', true),
+    ];
+    expect(isShielded(1, cells, true)).toBe(false);
+  });
+
+  it('returns true when next higher completed cell is not decayed', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('stale', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(true);
+  });
+
+  it('returns false when next higher completed cell is decayed', () => {
+    const cells = [
+      makeCell('aging', true),
+      makeCell('decayed', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(false);
+  });
+
+  it('skips incomplete cells when finding higher neighbor', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('incomplete', false),
+      makeCell('stale', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(true);
+  });
+
+  it('returns false for incomplete cell (never shielded)', () => {
+    const cells = [
+      makeCell('incomplete', false),
+      makeCell('fresh', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(false);
+  });
+
+  it('handles chain of 3 completed cells', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('aging', true),
+      makeCell('stale', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(true);
+    expect(isShielded(1, cells, true)).toBe(true);
+    expect(isShielded(2, cells, true)).toBe(false);
+  });
+
+  it('chain breaks when a cell decays', () => {
+    const cells = [
+      makeCell('fresh', true),
+      makeCell('stale', true),
+      makeCell('decayed', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(true);
+    expect(isShielded(1, cells, true)).toBe(false);
+    expect(isShielded(2, cells, true)).toBe(false);
+  });
+
+  it('single cell row — never shielded', () => {
+    const cells = [makeCell('fresh', true)];
+    expect(isShielded(0, cells, true)).toBe(false);
+  });
+
+  it('gap scenario: completed 0, incomplete 1+2, completed 3', () => {
+    const cells = [
+      makeCell('aging', true),
+      makeCell('incomplete', false),
+      makeCell('incomplete', false),
+      makeCell('stale', true),
+    ];
+    expect(isShielded(0, cells, true)).toBe(true);
+    expect(isShielded(3, cells, true)).toBe(false);
+  });
+});
+
+// ─── effectiveFreshnessState ─────────────────────────────────────────────────
+
+describe('effectiveFreshnessState', () => {
+  it('returns incomplete regardless of fade/shielding', () => {
+    expect(effectiveFreshnessState('incomplete', false, true)).toBe('incomplete');
+    expect(effectiveFreshnessState('incomplete', true, true)).toBe('incomplete');
+    expect(effectiveFreshnessState('incomplete', false, false)).toBe('incomplete');
+  });
+
+  it('returns fresh when fade is disabled (permanent green)', () => {
+    expect(effectiveFreshnessState('aging', false, false)).toBe('fresh');
+    expect(effectiveFreshnessState('stale', false, false)).toBe('fresh');
+    expect(effectiveFreshnessState('decayed', false, false)).toBe('fresh');
+    expect(effectiveFreshnessState('fresh', false, false)).toBe('fresh');
+  });
+
+  it('returns fresh when shielded', () => {
+    expect(effectiveFreshnessState('stale', true, true)).toBe('fresh');
+    expect(effectiveFreshnessState('aging', true, true)).toBe('fresh');
+    expect(effectiveFreshnessState('decayed', true, true)).toBe('fresh');
+  });
+
+  it('returns raw state when fade enabled and not shielded', () => {
+    expect(effectiveFreshnessState('fresh', false, true)).toBe('fresh');
+    expect(effectiveFreshnessState('aging', false, true)).toBe('aging');
+    expect(effectiveFreshnessState('stale', false, true)).toBe('stale');
+    expect(effectiveFreshnessState('decayed', false, true)).toBe('decayed');
   });
 });

--- a/tests/unit/models/freshness.test.ts
+++ b/tests/unit/models/freshness.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateFreshnessState,
+  calculateNewInterval,
+  type FreshnessState,
+} from '@/models/freshness';
+
+// ─── calculateFreshnessState ─────────────────────────────────────────────────
+
+describe('calculateFreshnessState', () => {
+  const now = new Date('2026-03-16T12:00:00Z');
+
+  it('returns incomplete when lastCompletionDate is null', () => {
+    expect(calculateFreshnessState(null, 1, now)).toBe('incomplete');
+  });
+
+  it('returns fresh when daysSince = 0 (completed today)', () => {
+    const today = new Date('2026-03-16T00:00:00Z');
+    expect(calculateFreshnessState(today, 4, now)).toBe('fresh');
+  });
+
+  it('returns fresh at exactly 50% of interval', () => {
+    const twoAgo = new Date('2026-03-14T00:00:00Z');
+    expect(calculateFreshnessState(twoAgo, 4, now)).toBe('fresh');
+  });
+
+  it('returns aging just past 50% of interval', () => {
+    const threeAgo = new Date('2026-03-13T00:00:00Z');
+    expect(calculateFreshnessState(threeAgo, 4, now)).toBe('aging');
+  });
+
+  it('returns aging at exactly 100% of interval', () => {
+    const fourAgo = new Date('2026-03-12T00:00:00Z');
+    expect(calculateFreshnessState(fourAgo, 4, now)).toBe('aging');
+  });
+
+  it('returns stale just past 100% of interval', () => {
+    const fiveAgo = new Date('2026-03-11T00:00:00Z');
+    expect(calculateFreshnessState(fiveAgo, 4, now)).toBe('stale');
+  });
+
+  it('returns stale at exactly 200% of interval', () => {
+    const eightAgo = new Date('2026-03-08T00:00:00Z');
+    expect(calculateFreshnessState(eightAgo, 4, now)).toBe('stale');
+  });
+
+  it('returns decayed past 200% of interval', () => {
+    const nineAgo = new Date('2026-03-07T00:00:00Z');
+    expect(calculateFreshnessState(nineAgo, 4, now)).toBe('decayed');
+  });
+
+  it('handles interval=1 boundaries correctly', () => {
+    const today = new Date('2026-03-16T00:00:00Z');
+    const yesterday = new Date('2026-03-15T00:00:00Z');
+    const twoDaysAgo = new Date('2026-03-14T00:00:00Z');
+    const threeDaysAgo = new Date('2026-03-13T00:00:00Z');
+
+    expect(calculateFreshnessState(today, 1, now)).toBe('fresh');
+    expect(calculateFreshnessState(yesterday, 1, now)).toBe('aging');
+    expect(calculateFreshnessState(twoDaysAgo, 1, now)).toBe('stale');
+    expect(calculateFreshnessState(threeDaysAgo, 1, now)).toBe('decayed');
+  });
+
+  it('uses floor for daysSince (partial days dont count)', () => {
+    const midnightToday = new Date('2026-03-16T00:00:00Z');
+    expect(calculateFreshnessState(midnightToday, 1, now)).toBe('fresh');
+  });
+});
+
+// ─── calculateNewInterval ────────────────────────────────────────────────────
+
+describe('calculateNewInterval', () => {
+  it('returns 1 for incomplete (first completion)', () => {
+    expect(calculateNewInterval(1, 'incomplete')).toBe(1);
+  });
+
+  it('returns 1 for incomplete even when currentInterval > 1 (post-reset scenario)', () => {
+    expect(calculateNewInterval(8, 'incomplete')).toBe(1);
+  });
+
+  it('doubles interval when fresh', () => {
+    expect(calculateNewInterval(1, 'fresh')).toBe(2);
+    expect(calculateNewInterval(2, 'fresh')).toBe(4);
+    expect(calculateNewInterval(4, 'fresh')).toBe(8);
+  });
+
+  it('doubles interval when aging', () => {
+    expect(calculateNewInterval(4, 'aging')).toBe(8);
+    expect(calculateNewInterval(8, 'aging')).toBe(16);
+  });
+
+  it('caps interval at 30', () => {
+    expect(calculateNewInterval(16, 'fresh')).toBe(30);
+    expect(calculateNewInterval(30, 'fresh')).toBe(30);
+    expect(calculateNewInterval(20, 'aging')).toBe(30);
+  });
+
+  it('resets to 1 when stale', () => {
+    expect(calculateNewInterval(8, 'stale')).toBe(1);
+    expect(calculateNewInterval(30, 'stale')).toBe(1);
+  });
+
+  it('resets to 1 when decayed', () => {
+    expect(calculateNewInterval(4, 'decayed')).toBe(1);
+    expect(calculateNewInterval(30, 'decayed')).toBe(1);
+  });
+
+  it('full progression: 1->2->4->8->16->30->30', () => {
+    let interval = 1;
+    const expected = [2, 4, 8, 16, 30, 30];
+    for (const exp of expected) {
+      interval = calculateNewInterval(interval, 'fresh');
+      expect(interval).toBe(exp);
+    }
+  });
+});

--- a/tests/unit/routes/api-routes.test.ts
+++ b/tests/unit/routes/api-routes.test.ts
@@ -15,6 +15,13 @@ vi.mock('@/controllers/grid', () => ({
   listGrids: vi.fn(() => NextResponse.json({ mock: 'listGrids' })),
   getGrid: vi.fn(() => NextResponse.json({ mock: 'getGrid' })),
   deleteGrid: vi.fn(() => new NextResponse(null, { status: 204 })),
+  updateFade: vi.fn(() => NextResponse.json({ mock: 'updateFade' })),
+}));
+
+vi.mock('@/controllers/cell', () => ({
+  completeCell: vi.fn(() => NextResponse.json({ mock: 'completeCell' }, { status: 201 })),
+  undoCompletion: vi.fn(() => NextResponse.json({ mock: 'undoCompletion' })),
+  resetCell: vi.fn(() => NextResponse.json({ mock: 'resetCell' })),
 }));
 
 vi.mock('@/controllers/piece', () => ({
@@ -187,5 +194,61 @@ describe('Row routes — /api/grids/[id]/rows/[rowId]/priority', () => {
 
     await PUT(req, params);
     expect(updatePriority).toHaveBeenCalledWith('grid-1', 'row-1', req);
+  });
+});
+
+// ─── Cell routes ──────────────────────────────────────────────────────────────
+
+describe('Cell routes — /api/grids/[id]/rows/[rowId]/cells/[cellId]/complete', () => {
+  it('POST extracts ids and delegates to completeCell', async () => {
+    const { POST } = await import('@/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/complete/route');
+    const { completeCell } = await import('@/controllers/cell');
+    const req = makeRequest('POST');
+    const params = makeParams({ id: 'grid-1', rowId: 'row-1', cellId: 'cell-1' });
+
+    const res = await POST(req, params);
+    expect(completeCell).toHaveBeenCalledWith('grid-1', 'row-1', 'cell-1');
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('Cell routes — /api/grids/[id]/rows/[rowId]/cells/[cellId]/undo', () => {
+  it('POST extracts ids and delegates to undoCompletion', async () => {
+    const { POST } = await import('@/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/undo/route');
+    const { undoCompletion } = await import('@/controllers/cell');
+    const req = makeRequest('POST');
+    const params = makeParams({ id: 'grid-1', rowId: 'row-1', cellId: 'cell-1' });
+
+    const res = await POST(req, params);
+    expect(undoCompletion).toHaveBeenCalledWith('grid-1', 'row-1', 'cell-1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('Cell routes — /api/grids/[id]/rows/[rowId]/cells/[cellId]/reset', () => {
+  it('POST extracts ids and delegates to resetCell', async () => {
+    const { POST } = await import('@/app/api/grids/[id]/rows/[rowId]/cells/[cellId]/reset/route');
+    const { resetCell } = await import('@/controllers/cell');
+    const req = makeRequest('POST');
+    const params = makeParams({ id: 'grid-1', rowId: 'row-1', cellId: 'cell-1' });
+
+    const res = await POST(req, params);
+    expect(resetCell).toHaveBeenCalledWith('grid-1', 'row-1', 'cell-1');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── Fade route ───────────────────────────────────────────────────────────────
+
+describe('Fade route — /api/grids/[id]/fade', () => {
+  it('PUT extracts id and delegates to updateFade', async () => {
+    const { PUT } = await import('@/app/api/grids/[id]/fade/route');
+    const { updateFade } = await import('@/controllers/grid');
+    const req = makeRequest('PUT');
+    const params = makeParams({ id: 'grid-1' });
+
+    const res = await PUT(req, params);
+    expect(updateFade).toHaveBeenCalledWith('grid-1', req);
+    expect(res.status).toBe(200);
   });
 });

--- a/tests/unit/views/grid.test.ts
+++ b/tests/unit/views/grid.test.ts
@@ -93,7 +93,7 @@ describe('Grid view — formatGridDetail', () => {
 
   // Test 13
   it('includes nested rows, cells, and completions with correct filtering', () => {
-    const result = formatGridDetail(mockGridWithRows);
+    const result = formatGridDetail(mockGridWithRows, new Date());
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].cells).toHaveLength(2);
     expect(result.rows[0].cells[0].completions).toHaveLength(1);
@@ -111,12 +111,12 @@ describe('Grid view — formatGridDetail', () => {
   // Test 14
   it('returns empty rows array when grid has no rows', () => {
     const emptyGrid = { ...mockGrid, practiceRows: [] };
-    const result = formatGridDetail(emptyGrid);
+    const result = formatGridDetail(emptyGrid, new Date());
     expect(result.rows).toEqual([]);
   });
 
   it('returns grid-level completionPercentage and freshnessSummary', () => {
-    const result = formatGridDetail(mockGridWithRows);
+    const result = formatGridDetail(mockGridWithRows, new Date());
     expect(result).toHaveProperty('completionPercentage');
     expect(result).toHaveProperty('freshnessSummary');
     expect(typeof result.completionPercentage).toBe('number');
@@ -131,7 +131,7 @@ describe('Grid view — formatGridDetail', () => {
     // mockGridWithRows has 2 cells: one with completion (aging at 1 day since), one incomplete
     // With fade enabled: cell-1 (completed, shielded by nothing higher completed → not shielded, aging)
     // cell-2 (incomplete)
-    const result = formatGridDetail(mockGridWithRows);
+    const result = formatGridDetail(mockGridWithRows, new Date());
     // cell-1: completed 2026-03-15, interval 1, now 2026-03-16 → 1 day since → aging (> 0.5*1, <= 1)
     // Not shielded: higher cell (cell-2) has no completions, skip it. cell-1 is highest completed → not shielded
     // effective: aging
@@ -144,7 +144,7 @@ describe('Grid view — formatGridDetail', () => {
 
   it('returns completionPercentage 0 for grid with empty rows', () => {
     const emptyGrid = { ...mockGrid, practiceRows: [] };
-    const result = formatGridDetail(emptyGrid);
+    const result = formatGridDetail(emptyGrid, new Date());
     expect(result.completionPercentage).toBe(0);
     expect(result.freshnessSummary).toEqual({
       fresh: 0,
@@ -187,7 +187,7 @@ describe('Grid view — tempo rounding', () => {
 
   // Test 17
   it('rounds cell tempo values to integers', () => {
-    const result = formatGridDetail(mockGridWithRows);
+    const result = formatGridDetail(mockGridWithRows, new Date());
     // 0.7333333 * 120 = 88.0 (but could be 87.99999...)
     // The view should round to the nearest integer
     const cell = result.rows[0].cells[1];

--- a/tests/unit/views/grid.test.ts
+++ b/tests/unit/views/grid.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { formatGrid, formatGridDetail, formatGridList } from '@/views/grid';
 
 const mockGrid = {
@@ -82,6 +82,15 @@ describe('Grid view — formatGrid', () => {
 });
 
 describe('Grid view — formatGridDetail', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-16T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // Test 13
   it('includes nested rows, cells, and completions with correct filtering', () => {
     const result = formatGridDetail(mockGridWithRows);
@@ -105,6 +114,46 @@ describe('Grid view — formatGridDetail', () => {
     const result = formatGridDetail(emptyGrid);
     expect(result.rows).toEqual([]);
   });
+
+  it('returns grid-level completionPercentage and freshnessSummary', () => {
+    const result = formatGridDetail(mockGridWithRows);
+    expect(result).toHaveProperty('completionPercentage');
+    expect(result).toHaveProperty('freshnessSummary');
+    expect(typeof result.completionPercentage).toBe('number');
+    expect(result.freshnessSummary).toHaveProperty('fresh');
+    expect(result.freshnessSummary).toHaveProperty('aging');
+    expect(result.freshnessSummary).toHaveProperty('stale');
+    expect(result.freshnessSummary).toHaveProperty('decayed');
+    expect(result.freshnessSummary).toHaveProperty('incomplete');
+  });
+
+  it('aggregates freshness across all rows for grid-level stats', () => {
+    // mockGridWithRows has 2 cells: one with completion (aging at 1 day since), one incomplete
+    // With fade enabled: cell-1 (completed, shielded by nothing higher completed → not shielded, aging)
+    // cell-2 (incomplete)
+    const result = formatGridDetail(mockGridWithRows);
+    // cell-1: completed 2026-03-15, interval 1, now 2026-03-16 → 1 day since → aging (> 0.5*1, <= 1)
+    // Not shielded: higher cell (cell-2) has no completions, skip it. cell-1 is highest completed → not shielded
+    // effective: aging
+    // cell-2: incomplete → incomplete
+    // completionPercentage with fade: aging counts → 1/2 = 50%
+    expect(result.completionPercentage).toBe(50);
+    expect(result.freshnessSummary.aging).toBe(1);
+    expect(result.freshnessSummary.incomplete).toBe(1);
+  });
+
+  it('returns completionPercentage 0 for grid with empty rows', () => {
+    const emptyGrid = { ...mockGrid, practiceRows: [] };
+    const result = formatGridDetail(emptyGrid);
+    expect(result.completionPercentage).toBe(0);
+    expect(result.freshnessSummary).toEqual({
+      fresh: 0,
+      aging: 0,
+      stale: 0,
+      decayed: 0,
+      incomplete: 0,
+    });
+  });
 });
 
 describe('Grid view — timestamps', () => {
@@ -127,6 +176,15 @@ describe('Grid view — formatGridList', () => {
 });
 
 describe('Grid view — tempo rounding', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-16T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // Test 17
   it('rounds cell tempo values to integers', () => {
     const result = formatGridDetail(mockGridWithRows);

--- a/tests/unit/views/row.test.ts
+++ b/tests/unit/views/row.test.ts
@@ -55,7 +55,7 @@ describe('Row View — formatRow', () => {
   });
 
   it('strips internal fields', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result).not.toHaveProperty('practiceGridId');
     expect(result).not.toHaveProperty('pieceId');
     expect(result).not.toHaveProperty('deletedAt');
@@ -63,13 +63,13 @@ describe('Row View — formatRow', () => {
   });
 
   it('formats timestamps as ISO 8601', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result.createdAt).toBe('2026-03-15T10:00:00.000Z');
     expect(result.updatedAt).toBe('2026-03-15T11:00:00.000Z');
   });
 
   it('includes nested piece without userId or deletedAt', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result.piece).toBeDefined();
     expect(result.piece!.title).toBe('Firebird Suite');
     expect(result.piece).not.toHaveProperty('userId');
@@ -79,24 +79,24 @@ describe('Row View — formatRow', () => {
 
   it('returns null piece when row has no piece', () => {
     const row = { ...baseRow, piece: null, pieceId: null };
-    const result = formatRow(row, true);
+    const result = formatRow(row, true, new Date());
     expect(result.piece).toBeNull();
   });
 
   it('calculates targetTempoBpm on cells', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     // 0.4 * 168 = 67.2 → rounds to 67
     expect(result.cells[0].targetTempoBpm).toBe(67);
   });
 
   it('strips internal fields from cells', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result.cells[0]).not.toHaveProperty('practiceRowId');
     expect(result.cells[0]).not.toHaveProperty('deletedAt');
   });
 
   it('returns freshnessState "incomplete" and lastCompletionDate null for cell with no completions', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result.cells[0].freshnessState).toBe('incomplete');
     expect(result.cells[0].lastCompletionDate).toBeNull();
     expect(result.cells[0].isShielded).toBe(false);
@@ -116,7 +116,7 @@ describe('Row View — formatRow', () => {
       ],
     };
     const row = { ...baseRow, practiceCells: [cellWithCompletion] };
-    const result = formatRow(row, true);
+    const result = formatRow(row, true, new Date());
     expect(result.cells[0].lastCompletionDate).toBe('2026-03-15');
   });
 
@@ -136,12 +136,12 @@ describe('Row View — formatRow', () => {
       ],
     };
     const row = { ...baseRow, practiceCells: [cellWithCompletion] };
-    const result = formatRow(row, true);
+    const result = formatRow(row, true, new Date());
     expect(result.cells[0].freshnessState).toBe('fresh');
   });
 
   it('returns completionPercentage and freshnessSummary', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result).toHaveProperty('completionPercentage');
     expect(result).toHaveProperty('freshnessSummary');
     expect(typeof result.completionPercentage).toBe('number');
@@ -153,7 +153,7 @@ describe('Row View — formatRow', () => {
   });
 
   it('computes completionPercentage 0 when all cells are incomplete', () => {
-    const result = formatRow(baseRow, true);
+    const result = formatRow(baseRow, true, new Date());
     expect(result.completionPercentage).toBe(0);
     expect(result.freshnessSummary.incomplete).toBe(1);
   });
@@ -165,7 +165,7 @@ describe('Row View — formatRow', () => {
       { ...baseCell, id: 'cell-mid', stepNumber: 1, targetTempoPercentage: 0.7, completions: [] },
     ];
     const row = { ...baseRow, practiceCells: cells };
-    const result = formatRow(row, true);
+    const result = formatRow(row, true, new Date());
     // Cells should be sorted by targetTempoPercentage ascending in output
     expect(result.cells[0].targetTempoPercentage).toBe(0.4);
     expect(result.cells[1].targetTempoPercentage).toBe(0.7);
@@ -206,13 +206,13 @@ describe('Row View — formatRow', () => {
     const row = { ...baseRow, practiceCells: cells };
 
     // With fade enabled: lower cell is shielded by higher (stale, not decayed)
-    const resultFade = formatRow(row, true);
+    const resultFade = formatRow(row, true, new Date());
     expect(resultFade.cells[0].isShielded).toBe(true);
     expect(resultFade.cells[0].freshnessState).toBe('fresh'); // shielded → fresh
     expect(resultFade.cells[1].isShielded).toBe(false);
 
     // With fade disabled: no shielding
-    const resultNoFade = formatRow(row, false);
+    const resultNoFade = formatRow(row, false, new Date());
     expect(resultNoFade.cells[0].isShielded).toBe(false);
     expect(resultNoFade.cells[0].freshnessState).toBe('fresh'); // fade off → all completed = fresh
   });

--- a/tests/unit/views/row.test.ts
+++ b/tests/unit/views/row.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { formatRow } from '@/views/row';
 
 const basePiece = {
@@ -44,8 +44,18 @@ const baseRow = {
 };
 
 describe('Row View — formatRow', () => {
+  // Pin "now" so freshness calculations are deterministic
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-16T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('strips internal fields', () => {
-    const result = formatRow(baseRow);
+    const result = formatRow(baseRow, true);
     expect(result).not.toHaveProperty('practiceGridId');
     expect(result).not.toHaveProperty('pieceId');
     expect(result).not.toHaveProperty('deletedAt');
@@ -53,13 +63,13 @@ describe('Row View — formatRow', () => {
   });
 
   it('formats timestamps as ISO 8601', () => {
-    const result = formatRow(baseRow);
+    const result = formatRow(baseRow, true);
     expect(result.createdAt).toBe('2026-03-15T10:00:00.000Z');
     expect(result.updatedAt).toBe('2026-03-15T11:00:00.000Z');
   });
 
   it('includes nested piece without userId or deletedAt', () => {
-    const result = formatRow(baseRow);
+    const result = formatRow(baseRow, true);
     expect(result.piece).toBeDefined();
     expect(result.piece!.title).toBe('Firebird Suite');
     expect(result.piece).not.toHaveProperty('userId');
@@ -69,19 +79,141 @@ describe('Row View — formatRow', () => {
 
   it('returns null piece when row has no piece', () => {
     const row = { ...baseRow, piece: null, pieceId: null };
-    const result = formatRow(row);
+    const result = formatRow(row, true);
     expect(result.piece).toBeNull();
   });
 
   it('calculates targetTempoBpm on cells', () => {
-    const result = formatRow(baseRow);
+    const result = formatRow(baseRow, true);
     // 0.4 * 168 = 67.2 → rounds to 67
     expect(result.cells[0].targetTempoBpm).toBe(67);
   });
 
   it('strips internal fields from cells', () => {
-    const result = formatRow(baseRow);
+    const result = formatRow(baseRow, true);
     expect(result.cells[0]).not.toHaveProperty('practiceRowId');
     expect(result.cells[0]).not.toHaveProperty('deletedAt');
+  });
+
+  it('returns freshnessState "incomplete" and lastCompletionDate null for cell with no completions', () => {
+    const result = formatRow(baseRow, true);
+    expect(result.cells[0].freshnessState).toBe('incomplete');
+    expect(result.cells[0].lastCompletionDate).toBeNull();
+    expect(result.cells[0].isShielded).toBe(false);
+  });
+
+  it('returns correct lastCompletionDate as YYYY-MM-DD string', () => {
+    const cellWithCompletion = {
+      ...baseCell,
+      completions: [
+        {
+          id: 'comp-1',
+          practiceCellId: 'cell-uuid',
+          completionDate: new Date('2026-03-15T00:00:00Z'),
+          createdAt: new Date('2026-03-15T10:00:00Z'),
+          deletedAt: null,
+        },
+      ],
+    };
+    const row = { ...baseRow, practiceCells: [cellWithCompletion] };
+    const result = formatRow(row, true);
+    expect(result.cells[0].lastCompletionDate).toBe('2026-03-15');
+  });
+
+  it('returns freshnessState "fresh" for a recently completed cell', () => {
+    // Completed today, interval 1 day, now is 2026-03-16 → 1 day since = aging (> 0.5 * 1)
+    // Need completion within 0.5 * interval → same day
+    const cellWithCompletion = {
+      ...baseCell,
+      completions: [
+        {
+          id: 'comp-1',
+          practiceCellId: 'cell-uuid',
+          completionDate: new Date('2026-03-16T00:00:00Z'),
+          createdAt: new Date('2026-03-16T00:00:00Z'),
+          deletedAt: null,
+        },
+      ],
+    };
+    const row = { ...baseRow, practiceCells: [cellWithCompletion] };
+    const result = formatRow(row, true);
+    expect(result.cells[0].freshnessState).toBe('fresh');
+  });
+
+  it('returns completionPercentage and freshnessSummary', () => {
+    const result = formatRow(baseRow, true);
+    expect(result).toHaveProperty('completionPercentage');
+    expect(result).toHaveProperty('freshnessSummary');
+    expect(typeof result.completionPercentage).toBe('number');
+    expect(result.freshnessSummary).toHaveProperty('fresh');
+    expect(result.freshnessSummary).toHaveProperty('aging');
+    expect(result.freshnessSummary).toHaveProperty('stale');
+    expect(result.freshnessSummary).toHaveProperty('decayed');
+    expect(result.freshnessSummary).toHaveProperty('incomplete');
+  });
+
+  it('computes completionPercentage 0 when all cells are incomplete', () => {
+    const result = formatRow(baseRow, true);
+    expect(result.completionPercentage).toBe(0);
+    expect(result.freshnessSummary.incomplete).toBe(1);
+  });
+
+  it('sorts cells by targetTempoPercentage for shielding', () => {
+    const cells = [
+      { ...baseCell, id: 'cell-high', stepNumber: 2, targetTempoPercentage: 1.0, completions: [] },
+      { ...baseCell, id: 'cell-low', stepNumber: 0, targetTempoPercentage: 0.4, completions: [] },
+      { ...baseCell, id: 'cell-mid', stepNumber: 1, targetTempoPercentage: 0.7, completions: [] },
+    ];
+    const row = { ...baseRow, practiceCells: cells };
+    const result = formatRow(row, true);
+    // Cells should be sorted by targetTempoPercentage ascending in output
+    expect(result.cells[0].targetTempoPercentage).toBe(0.4);
+    expect(result.cells[1].targetTempoPercentage).toBe(0.7);
+    expect(result.cells[2].targetTempoPercentage).toBe(1.0);
+  });
+
+  it('shields lower cells when fade is enabled and higher cell is not decayed', () => {
+    // Two cells, both completed recently. Lower cell should be shielded.
+    const now = new Date('2026-03-16T00:00:00Z');
+    const cells = [
+      {
+        ...baseCell,
+        id: 'cell-low',
+        stepNumber: 0,
+        targetTempoPercentage: 0.4,
+        completions: [{
+          id: 'comp-1',
+          practiceCellId: 'cell-low',
+          completionDate: new Date('2026-03-14T00:00:00Z'), // 2 days ago, stale for interval=1
+          createdAt: now,
+          deletedAt: null,
+        }],
+      },
+      {
+        ...baseCell,
+        id: 'cell-high',
+        stepNumber: 1,
+        targetTempoPercentage: 1.0,
+        completions: [{
+          id: 'comp-2',
+          practiceCellId: 'cell-high',
+          completionDate: new Date('2026-03-14T00:00:00Z'), // 2 days ago, stale for interval=1
+          createdAt: now,
+          deletedAt: null,
+        }],
+      },
+    ];
+    const row = { ...baseRow, practiceCells: cells };
+
+    // With fade enabled: lower cell is shielded by higher (stale, not decayed)
+    const resultFade = formatRow(row, true);
+    expect(resultFade.cells[0].isShielded).toBe(true);
+    expect(resultFade.cells[0].freshnessState).toBe('fresh'); // shielded → fresh
+    expect(resultFade.cells[1].isShielded).toBe(false);
+
+    // With fade disabled: no shielding
+    const resultNoFade = formatRow(row, false);
+    expect(resultNoFade.cells[0].isShielded).toBe(false);
+    expect(resultNoFade.cells[0].freshnessState).toBe('fresh'); // fade off → all completed = fresh
   });
 });


### PR DESCRIPTION
## Summary

Implements M1.5: Cell Completion & Freshness API — the spaced repetition engine for practice grids.

- **Cell completion** (POST .../complete): Records daily practice, updates freshness interval (double if fresh/aging, reset to 1 if stale/decayed/first)
- **Undo** (POST .../undo): Soft-deletes most recent completion (accidental clicks). Does not restore prior interval.
- **Reset** (POST .../reset): Keeps completions, resets interval to 1 ("I need to redo this")
- **Fade toggle** (PUT .../fade): Toggles freshness decay on/off per grid
- **Freshness calculations**: Pure functions for state (fresh/aging/stale/decayed/incomplete), cascading shielding (highest cell fades first, chain propagates), completion percentage, freshness summary
- **Schema migration**: Removes FreshnessResetStrategy enum (always reset to 1, no HALVE)

### Use Cases Covered
- UC-1.6: Mark Practice Cell Complete
- UC-1.7a: Undo Completion (new — split from UC-1.7)
- UC-1.7b: Reset Cell (new — split from UC-1.7)
- UC-1.8: View Freshness (calculation engine)
- UC-1.9: Cascading Fade
- UC-1.10: Completion Percentage

## Acceptance Criteria

| Criterion | Evidence |
|-----------|----------|
| Complete creates completion for today | `completions.test.ts`: "marks a cell complete and returns 201" |
| Duplicate same-day → 409 | `completions.test.ts`: "returns 409 if cell already completed today" |
| Undo soft-deletes most recent | `completions.test.ts`: "soft-deletes the most recent completion" |
| Undo with no completions → 409 | `completions.test.ts`: "returns 409 if no completions to undo" |
| Reset keeps completions, interval=1 | `completions.test.ts`: "resets interval to 1 and keeps completions" |
| Interval doubles on fresh/aging | `completions.test.ts`: "complete fresh cell: interval doubles" |
| Interval resets on stale/decayed | `completions.test.ts`: "complete stale cell: interval resets to 1" |
| Shielded cell uses raw state | `completions.test.ts`: "complete shielded cell: interval uses raw state" |
| Cascading fade: highest fades first | `completions.test.ts`: "fades highest cell first, then cascades down" |
| Fade toggle recalculates % | `completions.test.ts`: "toggle fade off/on" |
| Completion % includes stale (fade ON) | `freshness.test.ts`: "fade ON: fresh + aging + stale count" |
| YYYY-MM-DD date format | `completions.test.ts`: "completionDate is YYYY-MM-DD format" |
| Concurrent race → exactly one 201 | `completions.test.ts`: "concurrent same-day completion" |
| UTC date boundaries | `completions.test.ts`: "backdate to yesterday, complete again" |
| Grid detail includes freshness data | `grids.test.ts`: "includes completionPercentage and freshnessSummary" |

## Rejection Criteria

| Criterion | Status |
|-----------|--------|
| No hard deletes | ✅ Undo uses soft-delete (deletedAt) |
| ACID transactions | ✅ All cell operations in prisma.$transaction |
| No technical UI | ✅ Dates as YYYY-MM-DD, states as human strings |
| 95% coverage | ✅ All thresholds pass |
| No skipped tests | ✅ 391 tests, 0 skipped |

## Key Design Decisions (approved in brainstorming)

1. **Always reset to 1** — no HALVE strategy. Starting over is the point.
2. **Undo ≠ Reset** — two distinct operations with different semantics
3. **Stale counts toward completion %** — diverges from original spec (Willow approved). Stale is a warning, not failure.
4. **UTC everywhere** — timezone is a frontend concern (future: user-local practice days)
5. **Shielding uses raw state** — interval calculation ignores shielding (display-only concept)

## Bug Fixed During Review

`completeCell` was using `today` (the new completion date) instead of the prior last completion date when computing freshness state for interval calculation. Stale/decayed cells would always appear "fresh" and get their interval doubled instead of reset to 1. Fixed in commit f9cfb83.

## Stats
- 16 commits, 391 tests passing
- Coverage: all metrics above 95%
- Lint: zero errors, zero warnings
- Types: clean
- Build: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)