### PR TITLE
feat: M1.6 Grid View UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,10 +113,7 @@ The following are excluded from coverage in `vitest.config.ts`. Each must have a
 | Path | Reason |
 |------|--------|
 | `src/generated/**` | Prisma auto-generated client. Not our code; regenerated on every build. |
-| `src/components/**` | Empty directories (`.gitkeep` only). No code exists yet. Remove this exclusion when components are added (M2+). |
 | `src/app/globals.css` | CSS file, not executable code. |
-| `src/app/layout.tsx` | Next.js root layout — zero logic, pure JSX scaffolding (34 lines). Will gain tests when real UI work begins. |
-| `src/app/page.tsx` | Placeholder landing page — zero logic (10 lines). Will be replaced by real frontend. |
 
 **Rule:** When any excluded file gains application logic, it must be removed from the exclusion list and tested.
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -2696,7 +2696,8 @@ A milestone is complete when all its tasks pass their mapped acceptance criteria
 - Task: Progress bar showing grid completion %
 - Task: Responsive layout (320px+ viewports, adapts to large step counts)
 - Task: Playwright e2e tests with screenshots for each visual state
-- Maps to: UC-1.6, UC-1.7a, UC-1.7b, UC-1.11, UC-1.12
+- Maps to: UC-1.6, UC-1.7a, UC-1.11, UC-1.12
+- Note: UC-1.7b (Reset Cell) deferred to M1.9 — API exists, UI not yet needed
 
 **M1.7: Dashboard UI**
 - Task: Build 4-quadrant dashboard layout (responsive: 2x2 desktop, stacked mobile)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
+        "@tanstack/react-query": "^5.91.0",
         "next": "16.1.6",
         "pg": "^8.20.0",
         "react": "19.2.3",
@@ -19,6 +20,9 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -27,12 +31,20 @@
         "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^29.0.0",
         "prisma": "^7.5.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -46,6 +58,67 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -239,6 +312,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -297,6 +380,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
@@ -333,6 +429,146 @@
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.3.15",
@@ -981,6 +1217,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -2640,6 +2894,133 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.91.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.91.0.tgz",
+      "integrity": "sha512-FYXN8Kk9Q5VKuV6AIVaNwMThSi0nvAtR4X7HQoigf6ePOtFcavJYVIzgFhOVdtbBQtCJE3KimDIMMJM2DR1hjw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.91.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.91.0.tgz",
+      "integrity": "sha512-S8FODsDTNv0Ym+o/JVBvA6EWiWVhg6K2Q4qFehZyFKk6uW4H9OPbXl4kyiN9hAly0uHJ/1GEbR6kAI4MZWfjEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.91.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2650,6 +3031,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3512,6 +3901,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3814,6 +4214,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4136,6 +4546,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4149,6 +4580,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4222,6 +4667,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4292,6 +4744,17 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -4321,6 +4784,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -4397,6 +4868,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5666,6 +6150,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5732,6 +6229,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -6019,6 +6526,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -6270,6 +6784,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -6726,6 +7291,17 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6775,6 +7351,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6797,6 +7380,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7271,6 +7864,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7604,6 +8210,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prisma": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
@@ -7770,6 +8414,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7829,6 +8487,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -8019,6 +8687,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -8454,6 +9135,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8515,6 +9209,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
@@ -8612,6 +9313,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
+      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.26"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
+      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8623,6 +9344,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8836,6 +9583,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9390,6 +10147,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9521,6 +10326,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "verify": "eslint && tsc --noEmit && vitest run --coverage && next build"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
+    "@tanstack/react-query": "^5.91.0",
     "next": "16.1.6",
     "pg": "^8.20.0",
     "react": "19.2.3",
@@ -28,6 +30,9 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -36,6 +41,7 @@
     "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^29.0.0",
     "prisma": "^7.5.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,65 @@ async function main() {
   });
 
   console.log(`Seed user: ${seedUser.id} (${seedUser.email})`);
+
+  // ─── Dev/E2E fixture data (not production seed) ───────────────────────
+  // This data supports manual testing and Playwright e2e tests.
+  // It may be updated or replaced as UI milestones evolve.
+
+  const grid = await prisma.practiceGrid.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000001' },
+    update: {},
+    create: {
+      id: '00000000-0000-0000-0000-000000000001',
+      userId: seedUser.id,
+      name: 'Audition Prep — Week 1',
+      notes: 'Focus on Firebird excerpts and Clarke fundamentals',
+      fadeEnabled: true,
+    },
+  });
+
+  const piece = await prisma.piece.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000010' },
+    update: {},
+    create: {
+      id: '00000000-0000-0000-0000-000000000010',
+      userId: seedUser.id,
+      title: 'Clarke #3 in Eb',
+      composer: 'Herbert L. Clarke',
+    },
+  });
+
+  const row = await prisma.practiceRow.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000100' },
+    update: {},
+    create: {
+      id: '00000000-0000-0000-0000-000000000100',
+      practiceGridId: grid.id,
+      pieceId: piece.id,
+      sortOrder: 0,
+      startMeasure: 1,
+      endMeasure: 16,
+      targetTempo: 120,
+      steps: 5,
+      priority: 'HIGH',
+    },
+  });
+
+  const percentages = [0.4, 0.55, 0.7, 0.85, 1.0];
+  for (let i = 0; i < percentages.length; i++) {
+    await prisma.practiceCell.upsert({
+      where: { id: `00000000-0000-0000-0000-00000000100${i}` },
+      update: {},
+      create: {
+        id: `00000000-0000-0000-0000-00000000100${i}`,
+        practiceRowId: row.id,
+        stepNumber: i,
+        targetTempoPercentage: percentages[i],
+      },
+    });
+  }
+
+  console.log(`Seed grid: ${grid.id} (${grid.name})`);
   await prisma.$disconnect();
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #111827;
+  --foreground: #f9fafb;
 }
 
 @theme inline {
@@ -10,13 +10,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/grids/[id]/page.tsx
+++ b/src/app/grids/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { GridViewDirector } from '@/components/directors/GridViewDirector';
+
+export default async function GridDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <main style={{ backgroundColor: '#111827', minHeight: '100vh', padding: '24px', color: '#f9fafb' }}>
+      <GridViewDirector gridId={id} />
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { QueryProvider } from "@/lib/query-client";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,22 @@
+import { GridListDirector } from '@/components/directors/GridListDirector';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center">
-      <h1 className="text-4xl font-bold">Tessitura</h1>
-      <p className="mt-4 text-lg text-gray-600">
-        Practice grid platform for musicians
-      </p>
+    <main
+      style={{
+        backgroundColor: '#111827',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '48px 24px',
+        color: '#f9fafb',
+      }}
+    >
+      <h1 style={{ fontSize: '2.25rem', fontWeight: 'bold', marginBottom: '32px' }}>
+        Tessitura
+      </h1>
+      <GridListDirector />
     </main>
   );
 }

--- a/src/components/directors/GridListDirector.tsx
+++ b/src/components/directors/GridListDirector.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { GridList } from '@/components/presentation/GridList';
+
+interface ApiGrid {
+  id: string;
+  name: string;
+}
+
+async function fetchGrids(): Promise<ApiGrid[]> {
+  const response = await fetch('/api/grids');
+
+  if (response.status === 401) {
+    window.location.href = '/';
+    throw new Error('Unauthorized');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch grids: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function GridListDirector() {
+  const { data: grids, isLoading, error } = useQuery({
+    queryKey: ['grids'],
+    queryFn: fetchGrids,
+  });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Failed to load grids.</div>;
+  }
+
+  if (!grids) {
+    return null;
+  }
+
+  return <GridList grids={grids.map((g) => ({ id: g.id, name: g.name }))} />;
+}

--- a/src/components/directors/GridViewDirector.tsx
+++ b/src/components/directors/GridViewDirector.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { GridHeader } from '@/components/presentation/GridHeader';
+import { GridTable } from '@/components/presentation/GridTable';
+import type { FreshnessState } from '@/models/freshness';
+
+interface ApiCell {
+  id: string;
+  stepNumber: number;
+  targetTempoBpm: number;
+  freshnessState: FreshnessState;
+  lastCompletionDate: string | null;
+}
+
+interface ApiRow {
+  id: string;
+  piece: { id: string; title: string; composer: string | null; part: string | null; studyReference: string | null } | null;
+  passageLabel: string | null;
+  startMeasure: number;
+  endMeasure: number;
+  targetTempo: number;
+  priority: string;
+  cells: ApiCell[];
+}
+
+interface ApiGridDetail {
+  id: string;
+  name: string;
+  notes: string | null;
+  fadeEnabled: boolean;
+  completionPercentage: number;
+  freshnessSummary: {
+    fresh: number;
+    aging: number;
+    stale: number;
+    decayed: number;
+    incomplete: number;
+  };
+  rows: ApiRow[];
+}
+
+async function fetchGrid(gridId: string): Promise<ApiGridDetail> {
+  const response = await fetch(`/api/grids/${gridId}`);
+
+  if (response.status === 401) {
+    window.location.href = '/';
+    throw new Error('Unauthorized');
+  }
+
+  if (response.status === 404) {
+    throw new NotFoundError();
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch grid: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+class NotFoundError extends Error {
+  constructor() {
+    super('Grid not found');
+    this.name = 'NotFoundError';
+  }
+}
+
+function mapRows(rows: ApiRow[]) {
+  return rows.map((row) => ({
+    rowId: row.id,
+    piece: row.piece ? { title: row.piece.title, composer: row.piece.composer } : null,
+    passageLabel: row.passageLabel,
+    startMeasure: row.startMeasure,
+    endMeasure: row.endMeasure,
+    priority: row.priority,
+    cells: row.cells.map((cell) => ({
+      cellId: cell.id,
+      stepNumber: cell.stepNumber,
+      targetTempoBpm: cell.targetTempoBpm,
+      freshnessState: cell.freshnessState,
+      lastCompletionDate: cell.lastCompletionDate,
+    })),
+  }));
+}
+
+interface GridViewDirectorProps {
+  gridId: string;
+}
+
+export function GridViewDirector({ gridId }: GridViewDirectorProps) {
+  const queryClient = useQueryClient();
+  const queryKey = ['grid', gridId];
+
+  const { data: grid, isLoading, error } = useQuery({
+    queryKey,
+    queryFn: () => fetchGrid(gridId),
+  });
+
+  const completeMutation = useMutation({
+    mutationFn: async ({ rowId, cellId }: { rowId: string; cellId: string }) => {
+      const response = await fetch(
+        `/api/grids/${gridId}/rows/${rowId}/cells/${cellId}/complete`,
+        { method: 'POST' },
+      );
+      if (response.status === 409 || response.status === 404) {
+        return; // silently ignore
+      }
+      if (!response.ok) {
+        throw new Error(`Complete failed: ${response.status}`);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const undoMutation = useMutation({
+    mutationFn: async ({ rowId, cellId }: { rowId: string; cellId: string }) => {
+      const response = await fetch(
+        `/api/grids/${gridId}/rows/${rowId}/cells/${cellId}/undo`,
+        { method: 'POST' },
+      );
+      if (response.status === 409 || response.status === 404) {
+        return; // silently ignore
+      }
+      if (!response.ok) {
+        throw new Error(`Undo failed: ${response.status}`);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const fadeMutation = useMutation({
+    mutationFn: async (fadeEnabled: boolean) => {
+      const response = await fetch(`/api/grids/${gridId}/fade`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fadeEnabled }),
+      });
+      if (!response.ok) {
+        throw new Error(`Toggle fade failed: ${response.status}`);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const handleComplete = (rowId: string, cellId: string) => {
+    completeMutation.mutate({ rowId, cellId });
+  };
+
+  const handleUndo = (rowId: string, cellId: string) => {
+    undoMutation.mutate({ rowId, cellId });
+  };
+
+  const handleToggleFade = () => {
+    if (grid) {
+      fadeMutation.mutate(!grid.fadeEnabled);
+    }
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error instanceof NotFoundError) {
+    return <div>Grid not found</div>;
+  }
+
+  if (error) {
+    return <div>Error loading grid</div>;
+  }
+
+  if (!grid) {
+    return null;
+  }
+
+  return (
+    <div>
+      <GridHeader
+        name={grid.name}
+        notes={grid.notes}
+        fadeEnabled={grid.fadeEnabled}
+        completionPercentage={grid.completionPercentage}
+        freshnessSummary={grid.freshnessSummary}
+        onToggleFade={handleToggleFade}
+      />
+      <GridTable
+        rows={mapRows(grid.rows)}
+        onComplete={handleComplete}
+        onUndo={handleUndo}
+      />
+    </div>
+  );
+}

--- a/src/components/presentation/GridHeader.tsx
+++ b/src/components/presentation/GridHeader.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+
+interface FreshnessSummary {
+  fresh: number;
+  aging: number;
+  stale: number;
+  decayed: number;
+  incomplete: number;
+}
+
+export interface GridHeaderProps {
+  name: string;
+  notes: string | null;
+  fadeEnabled: boolean;
+  completionPercentage: number;
+  freshnessSummary: FreshnessSummary;
+  onToggleFade: () => void;
+}
+
+const FRESHNESS_DISPLAY: {
+  key: keyof FreshnessSummary;
+  label: string;
+  color: string;
+  border?: string;
+}[] = [
+  { key: 'fresh', label: 'fresh', color: '#10b981' },
+  { key: 'aging', label: 'aging', color: '#6ee7b7' },
+  { key: 'stale', label: 'stale', color: '#a7f3d0' },
+  { key: 'decayed', label: 'decayed', color: '#374151', border: '1px solid #6b7280' },
+  { key: 'incomplete', label: 'incomplete', color: '#374151', border: '1px solid #6b7280' },
+];
+
+export function GridHeader({
+  name,
+  notes,
+  fadeEnabled,
+  completionPercentage,
+  freshnessSummary,
+  onToggleFade,
+}: GridHeaderProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const roundedPct = Math.round(completionPercentage);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <h1 style={{ margin: 0 }}>{name}</h1>
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          aria-label={collapsed ? 'Expand header' : 'Collapse header'}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            color: '#9ca3af',
+          }}
+        >
+          {collapsed ? '▼' : '▲'}
+        </button>
+      </div>
+
+      {/* Progress bar — always visible */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '8px' }}>
+        <div
+          style={{
+            flex: 1,
+            height: '8px',
+            backgroundColor: '#374151',
+            borderRadius: '4px',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            data-testid="progress-fill"
+            style={{
+              width: `${roundedPct}%`,
+              height: '100%',
+              backgroundColor: '#10b981',
+              transition: 'width 0.3s ease',
+            }}
+          />
+        </div>
+        <span style={{ fontSize: '0.875rem', color: '#d1d5db' }}>{roundedPct}%</span>
+      </div>
+
+      {/* Fade toggle — always visible */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '8px' }}>
+        <span style={{ fontSize: '0.875rem', color: '#d1d5db' }}>Fade</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={fadeEnabled}
+          onClick={onToggleFade}
+          style={{
+            width: '36px',
+            height: '20px',
+            borderRadius: '10px',
+            border: 'none',
+            cursor: 'pointer',
+            backgroundColor: fadeEnabled ? '#10b981' : '#374151',
+            position: 'relative',
+            padding: 0,
+          }}
+        >
+          <div
+            style={{
+              width: '16px',
+              height: '16px',
+              borderRadius: '50%',
+              backgroundColor: '#ffffff',
+              position: 'absolute',
+              top: '2px',
+              left: fadeEnabled ? '18px' : '2px',
+              transition: 'left 0.2s ease',
+            }}
+          />
+        </button>
+      </div>
+
+      {/* Collapsible content */}
+      {!collapsed && (
+        <>
+          {notes && (
+            <p style={{ color: '#d1d5db', marginTop: '8px', fontSize: '0.875rem' }}>
+              {notes}
+            </p>
+          )}
+
+          {/* Freshness summary */}
+          <div style={{ display: 'flex', gap: '12px', marginTop: '12px', flexWrap: 'wrap' }}>
+            {FRESHNESS_DISPLAY.filter(({ key }) => freshnessSummary[key] > 0).map(
+              ({ key, label, color, border }) => (
+                <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  <div
+                    data-testid={`freshness-square-${key}`}
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      backgroundColor: color,
+                      border: border || 'none',
+                    }}
+                  />
+                  <span style={{ fontSize: '0.75rem', color: '#d1d5db' }}>
+                    {label}
+                  </span>
+                  <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
+                    {freshnessSummary[key]}
+                  </span>
+                </div>
+              ),
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/presentation/GridList.tsx
+++ b/src/components/presentation/GridList.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+interface GridSummary {
+  id: string;
+  name: string;
+}
+
+export interface GridListProps {
+  grids: GridSummary[];
+}
+
+export function GridList({ grids }: GridListProps) {
+  if (grids.length === 0) {
+    return (
+      <p style={{ color: '#9ca3af', fontSize: '1rem' }}>
+        No practice grids yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+      {grids.map((grid) => (
+        <li key={grid.id} style={{ marginBottom: '8px' }}>
+          <Link
+            href={`/grids/${grid.id}`}
+            style={{
+              color: '#60a5fa',
+              textDecoration: 'none',
+              fontSize: '1.125rem',
+            }}
+          >
+            {grid.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/presentation/GridRow.tsx
+++ b/src/components/presentation/GridRow.tsx
@@ -1,0 +1,78 @@
+import { PracticeCell } from '@/components/presentation/PracticeCell';
+import type { FreshnessState } from '@/models/freshness';
+
+interface CellData {
+  cellId: string;
+  stepNumber: number;
+  targetTempoBpm: number;
+  freshnessState: FreshnessState;
+  lastCompletionDate: string | null;
+}
+
+export interface GridRowProps {
+  rowId: string;
+  piece: { title: string; composer: string | null } | null;
+  passageLabel: string | null;
+  startMeasure: number;
+  endMeasure: number;
+  priority: string;
+  cells: CellData[];
+  onComplete: (rowId: string, cellId: string) => void;
+  onUndo: (rowId: string, cellId: string) => void;
+}
+
+const PRIORITY_COLORS: Record<string, string> = {
+  CRITICAL: '#ef4444',
+  HIGH: '#fbbf24',
+  MEDIUM: '#9ca3af',
+  LOW: '#9ca3af',
+};
+
+function getLabel(
+  piece: { title: string } | null,
+  passageLabel: string | null,
+): string {
+  if (piece && passageLabel) return `${piece.title} — ${passageLabel}`;
+  if (piece) return piece.title;
+  if (passageLabel) return passageLabel;
+  return 'Untitled';
+}
+
+export function GridRow({
+  rowId,
+  piece,
+  passageLabel,
+  startMeasure,
+  endMeasure,
+  priority,
+  cells,
+  onComplete,
+  onUndo,
+}: GridRowProps) {
+  const label = getLabel(piece, passageLabel);
+  const priorityColor = PRIORITY_COLORS[priority] || '#9ca3af';
+
+  return (
+    <tr>
+      <td style={{ whiteSpace: 'nowrap', padding: '4px 8px' }}>
+        <div>{label}</div>
+        <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
+          mm. {startMeasure}–{endMeasure} ·{' '}
+          <span style={{ color: priorityColor }}>{priority}</span>
+        </div>
+      </td>
+      {cells.map((cell) => (
+        <PracticeCell
+          key={cell.cellId}
+          cellId={cell.cellId}
+          stepNumber={cell.stepNumber}
+          targetTempoBpm={cell.targetTempoBpm}
+          freshnessState={cell.freshnessState}
+          lastCompletionDate={cell.lastCompletionDate}
+          onComplete={(cellId) => onComplete(rowId, cellId)}
+          onUndo={(cellId) => onUndo(rowId, cellId)}
+        />
+      ))}
+    </tr>
+  );
+}

--- a/src/components/presentation/GridTable.tsx
+++ b/src/components/presentation/GridTable.tsx
@@ -1,0 +1,54 @@
+import { GridRow } from '@/components/presentation/GridRow';
+import type { FreshnessState } from '@/models/freshness';
+
+interface RowCellData {
+  cellId: string;
+  stepNumber: number;
+  targetTempoBpm: number;
+  freshnessState: FreshnessState;
+  lastCompletionDate: string | null;
+}
+
+interface RowData {
+  rowId: string;
+  piece: { title: string; composer: string | null } | null;
+  passageLabel: string | null;
+  startMeasure: number;
+  endMeasure: number;
+  priority: string;
+  cells: RowCellData[];
+}
+
+export interface GridTableProps {
+  rows: RowData[];
+  onComplete: (rowId: string, cellId: string) => void;
+  onUndo: (rowId: string, cellId: string) => void;
+}
+
+export function GridTable({ rows, onComplete, onUndo }: GridTableProps) {
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table>
+        <tbody>
+          {rows.map((row) => (
+            <GridRow
+              key={row.rowId}
+              rowId={row.rowId}
+              piece={row.piece}
+              passageLabel={row.passageLabel}
+              startMeasure={row.startMeasure}
+              endMeasure={row.endMeasure}
+              priority={row.priority}
+              cells={row.cells}
+              onComplete={onComplete}
+              onUndo={onUndo}
+            />
+          ))}
+        </tbody>
+      </table>
+      <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '8px' }}>
+        Click to complete · Right-click to undo
+      </div>
+    </div>
+  );
+}

--- a/src/components/presentation/GridTable.tsx
+++ b/src/components/presentation/GridTable.tsx
@@ -28,7 +28,7 @@ export interface GridTableProps {
 export function GridTable({ rows, onComplete, onUndo }: GridTableProps) {
   return (
     <div style={{ overflowX: 'auto' }}>
-      <table>
+      <table aria-label="Practice grid">
         <tbody>
           {rows.map((row) => (
             <GridRow
@@ -47,7 +47,7 @@ export function GridTable({ rows, onComplete, onUndo }: GridTableProps) {
         </tbody>
       </table>
       <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '8px' }}>
-        Click to complete · Right-click to undo
+        Click to complete · Right-click or Delete key to undo
       </div>
     </div>
   );

--- a/src/components/presentation/PracticeCell.tsx
+++ b/src/components/presentation/PracticeCell.tsx
@@ -1,0 +1,75 @@
+import type { FreshnessState } from '@/models/freshness';
+
+export interface PracticeCellProps {
+  cellId: string;
+  stepNumber: number;
+  targetTempoBpm: number;
+  freshnessState: FreshnessState;
+  lastCompletionDate: string | null;
+  onComplete: (cellId: string) => void;
+  onUndo: (cellId: string) => void;
+}
+
+const FRESHNESS_COLORS: Record<FreshnessState, { backgroundColor: string; color: string }> = {
+  incomplete: { backgroundColor: '#1f2937', color: '#9ca3af' },
+  fresh: { backgroundColor: '#10b981', color: '#ffffff' },
+  aging: { backgroundColor: '#6ee7b7', color: '#064e3b' },
+  stale: { backgroundColor: '#a7f3d0', color: '#064e3b' },
+  decayed: { backgroundColor: '#1f2937', color: '#9ca3af' },
+};
+
+function formatDate(isoDate: string): string {
+  const parts = isoDate.split('-');
+  const month = String(Number(parts[1]));
+  const day = parts[2];
+  return `${month}-${day}`;
+}
+
+function showsBpm(state: FreshnessState): boolean {
+  return state === 'incomplete' || state === 'decayed';
+}
+
+export function PracticeCell({
+  cellId,
+  stepNumber,
+  targetTempoBpm,
+  freshnessState,
+  lastCompletionDate,
+  onComplete,
+  onUndo,
+}: PracticeCellProps) {
+  const colors = FRESHNESS_COLORS[freshnessState];
+  const isIncomplete = freshnessState === 'incomplete';
+  const displayText = showsBpm(freshnessState)
+    ? String(targetTempoBpm)
+    : formatDate(lastCompletionDate!);
+
+  const ariaLabel = isIncomplete
+    ? `Complete step ${stepNumber} at ${targetTempoBpm} BPM`
+    : `Undo step ${stepNumber}, completed ${formatDate(lastCompletionDate!)}`;
+
+  return (
+    <td>
+      <button
+        type="button"
+        style={{
+          backgroundColor: colors.backgroundColor,
+          color: colors.color,
+          width: '100%',
+          height: '100%',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '4px 8px',
+        }}
+        aria-label={ariaLabel}
+        onClick={() => onComplete(cellId)}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onUndo(cellId);
+        }}
+      >
+        {displayText}
+      </button>
+    </td>
+  );
+}

--- a/src/components/presentation/PracticeCell.tsx
+++ b/src/components/presentation/PracticeCell.tsx
@@ -21,7 +21,7 @@ const FRESHNESS_COLORS: Record<FreshnessState, { backgroundColor: string; color:
 function formatDate(isoDate: string): string {
   const parts = isoDate.split('-');
   const month = String(Number(parts[1]));
-  const day = parts[2];
+  const day = String(Number(parts[2]));
   return `${month}-${day}`;
 }
 
@@ -39,12 +39,11 @@ export function PracticeCell({
   onUndo,
 }: PracticeCellProps) {
   const colors = FRESHNESS_COLORS[freshnessState];
-  const isIncomplete = freshnessState === 'incomplete';
   const displayText = showsBpm(freshnessState)
     ? String(targetTempoBpm)
     : formatDate(lastCompletionDate!);
 
-  const ariaLabel = isIncomplete
+  const ariaLabel = showsBpm(freshnessState)
     ? `Complete step ${stepNumber} at ${targetTempoBpm} BPM`
     : `Undo step ${stepNumber}, completed ${formatDate(lastCompletionDate!)}`;
 
@@ -66,6 +65,12 @@ export function PracticeCell({
         onContextMenu={(e) => {
           e.preventDefault();
           onUndo(cellId);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Delete' || e.key === 'Backspace') {
+            e.preventDefault();
+            onUndo(cellId);
+          }
         }}
       >
         {displayText}

--- a/src/lib/query-client.tsx
+++ b/src/lib/query-client.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 0,
+            retry: 3,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/tests/e2e/grid-view.spec.ts
+++ b/tests/e2e/grid-view.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+// ─── Functional tests (use real API, no screenshots with dates) ─────────────
+
 test.describe('Grid View', () => {
   test('landing page shows grid list', async ({ page }) => {
     await page.goto('/');
@@ -15,7 +17,6 @@ test.describe('Grid View', () => {
   test('grid shows cells with BPM for incomplete cells', async ({ page }) => {
     await page.goto('/grids/00000000-0000-0000-0000-000000000001');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
-    // First cell should show BPM (48 = round(0.4 * 120))
     await expect(page.getByRole('button', { name: /48 BPM/ })).toBeVisible();
   });
 
@@ -23,20 +24,16 @@ test.describe('Grid View', () => {
     await page.goto('/grids/00000000-0000-0000-0000-000000000001');
     const cell = page.getByRole('button', { name: /Complete step 1 at 48 BPM/ });
     await cell.click();
-    // After completion, the cell should show a date-based aria-label
     await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
   });
 
   test('right-click completed cell to undo', async ({ page }) => {
     await page.goto('/grids/00000000-0000-0000-0000-000000000001');
-    // Complete a cell first
     const cell = page.getByRole('button', { name: /Complete step 1 at 48 BPM/ });
     await cell.click();
     await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
-    // Right-click to undo
     const undoCell = page.getByRole('button', { name: /Undo step 1/ });
     await undoCell.click({ button: 'right' });
-    // Should revert to BPM display
     await expect(page.getByRole('button', { name: /Complete step 1 at 48 BPM/ })).toBeVisible();
   });
 
@@ -59,6 +56,68 @@ test.describe('Grid View', () => {
   });
 });
 
+// ─── Visual regression screenshots (mocked API for deterministic dates) ─────
+
+/**
+ * Fixed grid response for screenshot tests. Dates are pinned so screenshots
+ * don't drift when run on different days. Includes a mix of freshness states:
+ * - Cell 1: fresh (completed 2026-03-15)
+ * - Cell 2: fresh (completed 2026-03-15, shielded)
+ * - Cell 3: incomplete
+ * - Cell 4: incomplete
+ * - Cell 5: incomplete
+ */
+const MOCK_GRID_RESPONSE = {
+  id: '00000000-0000-0000-0000-000000000001',
+  name: 'Audition Prep — Week 1',
+  notes: 'Focus on Firebird excerpts and Clarke fundamentals',
+  fadeEnabled: true,
+  completionPercentage: 40,
+  freshnessSummary: { fresh: 2, aging: 0, stale: 0, decayed: 0, incomplete: 3 },
+  createdAt: '2026-03-10T00:00:00.000Z',
+  updatedAt: '2026-03-15T00:00:00.000Z',
+  rows: [
+    {
+      id: '00000000-0000-0000-0000-000000000100',
+      sortOrder: 0,
+      piece: { id: '00000000-0000-0000-0000-000000000010', title: 'Clarke #3 in Eb', composer: 'Herbert L. Clarke' },
+      passageLabel: null,
+      startMeasure: 1,
+      endMeasure: 16,
+      targetTempo: 120,
+      steps: 5,
+      priority: 'HIGH',
+      completionPercentage: 40,
+      freshnessSummary: { fresh: 2, aging: 0, stale: 0, decayed: 0, incomplete: 3 },
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-15T00:00:00.000Z',
+      cells: [
+        { id: 'c0', stepNumber: 0, targetTempoPercentage: 0.4, targetTempoBpm: 48, freshnessIntervalDays: 2, freshnessState: 'fresh', lastCompletionDate: '2026-03-15', isShielded: true, createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-15T00:00:00.000Z', completions: [{ id: 'comp-0', completionDate: '2026-03-15', createdAt: '2026-03-15T10:00:00.000Z' }] },
+        { id: 'c1', stepNumber: 1, targetTempoPercentage: 0.55, targetTempoBpm: 66, freshnessIntervalDays: 1, freshnessState: 'fresh', lastCompletionDate: '2026-03-15', isShielded: false, createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-15T00:00:00.000Z', completions: [{ id: 'comp-1', completionDate: '2026-03-15', createdAt: '2026-03-15T10:00:00.000Z' }] },
+        { id: 'c2', stepNumber: 2, targetTempoPercentage: 0.7, targetTempoBpm: 84, freshnessIntervalDays: 1, freshnessState: 'incomplete', lastCompletionDate: null, isShielded: false, createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-10T00:00:00.000Z', completions: [] },
+        { id: 'c3', stepNumber: 3, targetTempoPercentage: 0.85, targetTempoBpm: 102, freshnessIntervalDays: 1, freshnessState: 'incomplete', lastCompletionDate: null, isShielded: false, createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-10T00:00:00.000Z', completions: [] },
+        { id: 'c4', stepNumber: 4, targetTempoPercentage: 1.0, targetTempoBpm: 120, freshnessIntervalDays: 1, freshnessState: 'incomplete', lastCompletionDate: null, isShielded: false, createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-10T00:00:00.000Z', completions: [] },
+      ],
+    },
+  ],
+};
+
+/** Same grid but with fadeEnabled=false — all completed cells show as 'fresh' */
+const MOCK_GRID_FADE_OFF = {
+  ...MOCK_GRID_RESPONSE,
+  fadeEnabled: false,
+  completionPercentage: 40,
+  rows: MOCK_GRID_RESPONSE.rows.map((row) => ({
+    ...row,
+    cells: row.cells.map((cell) => ({
+      ...cell,
+      // With fade off, completed cells all show 'fresh', incomplete stay 'incomplete'
+      freshnessState: cell.freshnessState === 'incomplete' ? 'incomplete' : 'fresh',
+      isShielded: false,
+    })),
+  })),
+};
+
 test.describe('Grid View — Visual Regression Screenshots', () => {
   test('landing page grid list', async ({ page }) => {
     await page.goto('/');
@@ -67,27 +126,47 @@ test.describe('Grid View — Visual Regression Screenshots', () => {
   });
 
   test('grid detail with freshness states', async ({ page }) => {
+    // Mock the API to return fixed dates — no real completions created
+    await page.route('**/api/grids/00000000-0000-0000-0000-000000000001', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GRID_RESPONSE),
+      });
+    });
+
     await page.goto('/grids/00000000-0000-0000-0000-000000000001');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
-    // Complete first two cells to create a mix of states
-    const cell1 = page.getByRole('button', { name: /Complete step 1/ });
-    await cell1.click();
-    await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
-    const cell2 = page.getByRole('button', { name: /Complete step 2/ });
-    await cell2.click();
-    await expect(page.getByRole('button', { name: /Undo step 2/ })).toBeVisible();
+    // Cells should show fixed dates (3-15) not today's date
+    await expect(page.getByRole('button', { name: /Undo step 1, completed 3-15/ })).toBeVisible();
     await expect(page).toHaveScreenshot('grid-detail-freshness-states.png');
   });
 
-  test('grid detail with fade disabled vs enabled', async ({ page }) => {
+  test('grid detail fade disabled', async ({ page }) => {
+    await page.route('**/api/grids/00000000-0000-0000-0000-000000000001', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GRID_FADE_OFF),
+      });
+    });
+
     await page.goto('/grids/00000000-0000-0000-0000-000000000001');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
-    const fadeToggle = page.getByRole('switch', { name: 'Toggle fade' });
-    await fadeToggle.click();
-    await page.waitForTimeout(500);
     await expect(page).toHaveScreenshot('grid-detail-fade-disabled.png');
-    await fadeToggle.click();
-    await page.waitForTimeout(500);
+  });
+
+  test('grid detail fade enabled', async ({ page }) => {
+    await page.route('**/api/grids/00000000-0000-0000-0000-000000000001', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GRID_RESPONSE),
+      });
+    });
+
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
     await expect(page).toHaveScreenshot('grid-detail-fade-enabled.png');
   });
 });

--- a/tests/e2e/grid-view.spec.ts
+++ b/tests/e2e/grid-view.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Grid View', () => {
+  test('landing page shows grid list', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Audition Prep — Week 1')).toBeVisible();
+  });
+
+  test('navigate to grid detail page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Audition Prep — Week 1').click();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
+  });
+
+  test('grid shows cells with BPM for incomplete cells', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
+    // First cell should show BPM (48 = round(0.4 * 120))
+    await expect(page.getByRole('button', { name: /48 BPM/ })).toBeVisible();
+  });
+
+  test('click cell to complete, verify it turns green', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    const cell = page.getByRole('button', { name: /Complete step 1 at 48 BPM/ });
+    await cell.click();
+    // After completion, the cell should show a date-based aria-label
+    await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
+  });
+
+  test('right-click completed cell to undo', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    // Complete a cell first
+    const cell = page.getByRole('button', { name: /Complete step 1 at 48 BPM/ });
+    await cell.click();
+    await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
+    // Right-click to undo
+    const undoCell = page.getByRole('button', { name: /Undo step 1/ });
+    await undoCell.click({ button: 'right' });
+    // Should revert to BPM display
+    await expect(page.getByRole('button', { name: /Complete step 1 at 48 BPM/ })).toBeVisible();
+  });
+
+  test('fade toggle is visible and clickable', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    const fadeToggle = page.getByRole('switch', { name: 'Toggle fade' });
+    await expect(fadeToggle).toBeVisible();
+    await fadeToggle.click();
+    await fadeToggle.click();
+  });
+
+  test('helper legend is visible', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    await expect(page.getByText('Click to complete')).toBeVisible();
+  });
+
+  test('grid not found shows message', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-999999999999');
+    await expect(page.getByText('Grid not found')).toBeVisible();
+  });
+});
+
+test.describe('Grid View — Visual Regression Screenshots', () => {
+  test('landing page grid list', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Audition Prep — Week 1')).toBeVisible();
+    await expect(page).toHaveScreenshot('landing-page-grid-list.png');
+  });
+
+  test('grid detail with freshness states', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
+    // Complete first two cells to create a mix of states
+    const cell1 = page.getByRole('button', { name: /Complete step 1/ });
+    await cell1.click();
+    await expect(page.getByRole('button', { name: /Undo step 1/ })).toBeVisible();
+    const cell2 = page.getByRole('button', { name: /Complete step 2/ });
+    await cell2.click();
+    await expect(page.getByRole('button', { name: /Undo step 2/ })).toBeVisible();
+    await expect(page).toHaveScreenshot('grid-detail-freshness-states.png');
+  });
+
+  test('grid detail with fade disabled vs enabled', async ({ page }) => {
+    await page.goto('/grids/00000000-0000-0000-0000-000000000001');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Audition Prep');
+    const fadeToggle = page.getByRole('switch', { name: 'Toggle fade' });
+    await fadeToggle.click();
+    await page.waitForTimeout(500);
+    await expect(page).toHaveScreenshot('grid-detail-fade-disabled.png');
+    await fadeToggle.click();
+    await page.waitForTimeout(500);
+    await expect(page).toHaveScreenshot('grid-detail-fade-enabled.png');
+  });
+});

--- a/tests/integration/components/GridViewDirector.test.tsx
+++ b/tests/integration/components/GridViewDirector.test.tsx
@@ -1,0 +1,369 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GridViewDirector } from '@/components/directors/GridViewDirector';
+
+afterEach(() => cleanup());
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = makeQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+const GRID_ID = 'grid-abc-123';
+
+function makeGridResponse() {
+  return {
+    id: GRID_ID,
+    name: 'Bach Partita Practice',
+    notes: 'Focus on intonation',
+    fadeEnabled: true,
+    completionPercentage: 33.33,
+    freshnessSummary: {
+      fresh: 1,
+      aging: 0,
+      stale: 0,
+      decayed: 0,
+      incomplete: 2,
+    },
+    createdAt: '2026-03-15T00:00:00.000Z',
+    updatedAt: '2026-03-15T00:00:00.000Z',
+    rows: [
+      {
+        id: 'row-1',
+        sortOrder: 0,
+        piece: { id: 'piece-1', title: 'Partita No. 2', composer: 'Bach', part: null, studyReference: null },
+        passageLabel: 'Allemande',
+        startMeasure: 1,
+        endMeasure: 8,
+        targetTempo: 72,
+        steps: 3,
+        priority: 'HIGH',
+        completionPercentage: 33.33,
+        freshnessSummary: { fresh: 1, aging: 0, stale: 0, decayed: 0, incomplete: 2 },
+        createdAt: '2026-03-15T00:00:00.000Z',
+        updatedAt: '2026-03-15T00:00:00.000Z',
+        cells: [
+          {
+            id: 'cell-1',
+            stepNumber: 1,
+            targetTempoPercentage: 0.6,
+            targetTempoBpm: 43,
+            freshnessIntervalDays: 2,
+            freshnessState: 'fresh',
+            lastCompletionDate: '2026-03-18',
+            isShielded: false,
+            createdAt: '2026-03-15T00:00:00.000Z',
+            updatedAt: '2026-03-15T00:00:00.000Z',
+            completions: [{ id: 'comp-1', completionDate: '2026-03-18', createdAt: '2026-03-18T00:00:00.000Z' }],
+          },
+          {
+            id: 'cell-2',
+            stepNumber: 2,
+            targetTempoPercentage: 0.8,
+            targetTempoBpm: 58,
+            freshnessIntervalDays: 1,
+            freshnessState: 'incomplete',
+            lastCompletionDate: null,
+            isShielded: false,
+            createdAt: '2026-03-15T00:00:00.000Z',
+            updatedAt: '2026-03-15T00:00:00.000Z',
+            completions: [],
+          },
+          {
+            id: 'cell-3',
+            stepNumber: 3,
+            targetTempoPercentage: 1.0,
+            targetTempoBpm: 72,
+            freshnessIntervalDays: 1,
+            freshnessState: 'incomplete',
+            lastCompletionDate: null,
+            isShielded: false,
+            createdAt: '2026-03-15T00:00:00.000Z',
+            updatedAt: '2026-03-15T00:00:00.000Z',
+            completions: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('GridViewDirector', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows loading state initially', () => {
+    fetchSpy.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders grid after fetch succeeds', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => makeGridResponse(),
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+    });
+
+    // Grid name in heading
+    expect(screen.getByRole('heading', { name: 'Bach Partita Practice' })).toBeInTheDocument();
+
+    // Fade toggle button present
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+
+    // Verify fetch was called with correct URL
+    expect(fetchSpy).toHaveBeenCalledWith(`/api/grids/${GRID_ID}`);
+  });
+
+  it('shows "Grid not found" for 404', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Not found' }),
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Grid not found')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to / on 401', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+      configurable: true,
+    });
+
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Unauthorized' }),
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('/');
+    });
+  });
+
+  it('calls complete endpoint on cell click and triggers refetch', async () => {
+    const user = userEvent.setup();
+    const gridData = makeGridResponse();
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    // Wait for grid to load
+    await waitFor(() => {
+      expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+    });
+
+    // Click the incomplete cell (cell-2, shows BPM "58")
+    const incompleteButton = screen.getByLabelText('Complete step 2 at 58 BPM');
+
+    // Reset fetch mock to track the mutation call
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    await user.click(incompleteButton);
+
+    await waitFor(() => {
+      // Check that the complete endpoint was called
+      const calls = fetchSpy.mock.calls;
+      const completeCall = calls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('/complete'),
+      );
+      expect(completeCall).toBeTruthy();
+      expect(completeCall![0]).toBe(
+        `/api/grids/${GRID_ID}/rows/row-1/cells/cell-2/complete`,
+      );
+      expect(completeCall![1]).toEqual(
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    // Check that refetch was triggered (grid endpoint called again)
+    await waitFor(() => {
+      const refetchCall = fetchSpy.mock.calls.find(
+        (call: unknown[]) => call[0] === `/api/grids/${GRID_ID}`,
+      );
+      expect(refetchCall).toBeTruthy();
+    });
+  });
+
+  it('calls undo endpoint on cell right-click', async () => {
+    const gridData = makeGridResponse();
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+    });
+
+    // Right-click on cell-1 (fresh cell, shows date "3-18")
+    const freshButton = screen.getByLabelText('Undo step 1, completed 3-18');
+
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.contextMenu(freshButton);
+
+    await waitFor(() => {
+      const undoCall = fetchSpy.mock.calls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('/undo'),
+      );
+      expect(undoCall).toBeTruthy();
+      expect(undoCall![0]).toBe(
+        `/api/grids/${GRID_ID}/rows/row-1/cells/cell-1/undo`,
+      );
+      expect(undoCall![1]).toEqual(
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  it('calls fade toggle endpoint when fade switch is clicked', async () => {
+    const user = userEvent.setup();
+    const gridData = makeGridResponse();
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+    });
+
+    const fadeSwitch = screen.getByRole('switch');
+
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ...gridData, fadeEnabled: false }),
+    });
+
+    await user.click(fadeSwitch);
+
+    await waitFor(() => {
+      const fadeCall = fetchSpy.mock.calls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('/fade'),
+      );
+      expect(fadeCall).toBeTruthy();
+      expect(fadeCall![0]).toBe(`/api/grids/${GRID_ID}/fade`);
+      expect(fadeCall![1]).toEqual(
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ fadeEnabled: false }),
+        }),
+      );
+    });
+  });
+
+  it('silently handles 409 on complete mutation', async () => {
+    const user = userEvent.setup();
+    const gridData = makeGridResponse();
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    renderWithQuery(<GridViewDirector gridId={GRID_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+    });
+
+    const incompleteButton = screen.getByLabelText('Complete step 2 at 58 BPM');
+
+    fetchSpy.mockClear();
+    // Complete returns 409
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'Already completed' }),
+    });
+    // Refetch returns grid data
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => gridData,
+    });
+
+    await user.click(incompleteButton);
+
+    // Should not show any error, and should refetch
+    await waitFor(() => {
+      const refetchCall = fetchSpy.mock.calls.find(
+        (call: unknown[]) => call[0] === `/api/grids/${GRID_ID}`,
+      );
+      expect(refetchCall).toBeTruthy();
+    });
+
+    // Grid should still be visible (no error state)
+    expect(screen.getByText('Bach Partita Practice')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/directors/GridListDirector.test.tsx
+++ b/tests/unit/components/directors/GridListDirector.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GridListDirector } from '@/components/directors/GridListDirector';
+
+afterEach(() => cleanup());
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('GridListDirector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    global.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<GridListDirector />, { wrapper: createWrapper() });
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders grid list after fetch succeeds', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'g1', name: 'Grid One' },
+        { id: 'g2', name: 'Grid Two' },
+      ]),
+    }) as unknown as typeof fetch;
+
+    render(<GridListDirector />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Grid One')).toBeInTheDocument();
+      expect(screen.getByText('Grid Two')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no grids', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    }) as unknown as typeof fetch;
+
+    render(<GridListDirector />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('No practice grids yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state on fetch failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }) as unknown as typeof fetch;
+
+    render(<GridListDirector />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load grids.')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/presentation/GridHeader.test.tsx
+++ b/tests/unit/components/presentation/GridHeader.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { GridHeader, type GridHeaderProps } from '@/components/presentation/GridHeader';
+
+afterEach(() => cleanup());
+
+function makeHeader(overrides: Partial<GridHeaderProps> = {}): GridHeaderProps {
+  return {
+    name: 'Bach Inventions',
+    notes: 'Focus on voice independence',
+    fadeEnabled: true,
+    completionPercentage: 65,
+    freshnessSummary: {
+      fresh: 10,
+      aging: 5,
+      stale: 3,
+      decayed: 2,
+      incomplete: 0,
+    },
+    onToggleFade: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('GridHeader', () => {
+  describe('basic rendering', () => {
+    it('renders the grid name as h1', () => {
+      render(<GridHeader {...makeHeader()} />);
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading).toHaveTextContent('Bach Inventions');
+    });
+
+    it('renders notes when present', () => {
+      render(<GridHeader {...makeHeader({ notes: 'Some notes here' })} />);
+      expect(screen.getByText('Some notes here')).toBeInTheDocument();
+    });
+
+    it('does not render notes section when null', () => {
+      render(<GridHeader {...makeHeader({ notes: null })} />);
+      expect(screen.queryByText('Focus on voice independence')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('completion percentage', () => {
+    it('displays completion percentage', () => {
+      render(<GridHeader {...makeHeader({ completionPercentage: 65 })} />);
+      expect(screen.getByText('65%')).toBeInTheDocument();
+    });
+
+    it('renders progress bar with correct fill width', () => {
+      render(<GridHeader {...makeHeader({ completionPercentage: 42 })} />);
+      const progressFill = screen.getByTestId('progress-fill');
+      expect(progressFill).toHaveStyle({ width: '42%' });
+    });
+  });
+
+  describe('freshness summary', () => {
+    it('shows only non-zero freshness states', () => {
+      render(<GridHeader {...makeHeader({
+        freshnessSummary: { fresh: 10, aging: 5, stale: 0, decayed: 2, incomplete: 0 },
+      })} />);
+      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      // stale=0 and incomplete=0 should not be shown
+      expect(screen.queryByText('stale')).not.toBeInTheDocument();
+      expect(screen.queryByText('incomplete')).not.toBeInTheDocument();
+    });
+
+    it('renders freshness squares with correct colors', () => {
+      render(<GridHeader {...makeHeader({
+        freshnessSummary: { fresh: 3, aging: 0, stale: 0, decayed: 1, incomplete: 0 },
+      })} />);
+      const freshSquare = screen.getByTestId('freshness-square-fresh');
+      expect(freshSquare).toHaveStyle({ backgroundColor: '#10b981' });
+      const decayedSquare = screen.getByTestId('freshness-square-decayed');
+      expect(decayedSquare).toHaveStyle({ backgroundColor: '#374151' });
+    });
+  });
+
+  describe('fade toggle', () => {
+    it('calls onToggleFade when clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleFade = vi.fn();
+      render(<GridHeader {...makeHeader({ onToggleFade })} />);
+      const toggle = screen.getByRole('switch');
+      await user.click(toggle);
+      expect(onToggleFade).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows green when fade is enabled', () => {
+      render(<GridHeader {...makeHeader({ fadeEnabled: true })} />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+      expect(toggle).toHaveStyle({ backgroundColor: '#10b981' });
+    });
+
+    it('shows gray when fade is disabled', () => {
+      render(<GridHeader {...makeHeader({ fadeEnabled: false })} />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+      expect(toggle).toHaveStyle({ backgroundColor: '#374151' });
+    });
+  });
+
+  describe('collapse/expand', () => {
+    it('hides notes and summary when collapsed', async () => {
+      const user = userEvent.setup();
+      render(<GridHeader {...makeHeader({ notes: 'Some notes' })} />);
+      // Find and click the collapse button
+      const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+      await user.click(collapseBtn);
+      // Notes should be hidden
+      expect(screen.queryByText('Some notes')).not.toBeInTheDocument();
+      // Freshness labels should be hidden
+      expect(screen.queryByText('fresh')).not.toBeInTheDocument();
+    });
+
+    it('restores notes and summary when expanded again', async () => {
+      const user = userEvent.setup();
+      render(<GridHeader {...makeHeader({ notes: 'Some notes' })} />);
+      const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+      await user.click(collapseBtn);
+      // Now expand
+      const expandBtn = screen.getByRole('button', { name: /expand/i });
+      await user.click(expandBtn);
+      expect(screen.getByText('Some notes')).toBeInTheDocument();
+    });
+
+    it('still shows name when collapsed', async () => {
+      const user = userEvent.setup();
+      render(<GridHeader {...makeHeader()} />);
+      const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+      await user.click(collapseBtn);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Bach Inventions');
+    });
+
+    it('still shows progress bar when collapsed', async () => {
+      const user = userEvent.setup();
+      render(<GridHeader {...makeHeader({ completionPercentage: 65 })} />);
+      const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+      await user.click(collapseBtn);
+      expect(screen.getByText('65%')).toBeInTheDocument();
+    });
+
+    it('still shows fade toggle when collapsed', async () => {
+      const user = userEvent.setup();
+      render(<GridHeader {...makeHeader()} />);
+      const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+      await user.click(collapseBtn);
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/presentation/GridList.test.tsx
+++ b/tests/unit/components/presentation/GridList.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { GridList } from '@/components/presentation/GridList';
+
+afterEach(() => cleanup());
+
+describe('GridList', () => {
+  it('renders links with correct hrefs for each grid', () => {
+    const grids = [
+      { id: 'grid-1', name: 'Bach Partita' },
+      { id: 'grid-2', name: 'Scales Practice' },
+    ];
+
+    render(<GridList grids={grids} />);
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+
+    expect(links[0]).toHaveTextContent('Bach Partita');
+    expect(links[0]).toHaveAttribute('href', '/grids/grid-1');
+
+    expect(links[1]).toHaveTextContent('Scales Practice');
+    expect(links[1]).toHaveAttribute('href', '/grids/grid-2');
+  });
+
+  it('renders empty state when no grids', () => {
+    render(<GridList grids={[]} />);
+
+    expect(screen.getByText('No practice grids yet.')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/tests/unit/components/presentation/GridRow.test.tsx
+++ b/tests/unit/components/presentation/GridRow.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { GridRow, type GridRowProps } from '@/components/presentation/GridRow';
+import type { FreshnessState } from '@/models/freshness';
+
+afterEach(() => cleanup());
+
+function makeCell(overrides: Partial<GridRowProps['cells'][number]> = {}): GridRowProps['cells'][number] {
+  return {
+    cellId: 'cell-1',
+    stepNumber: 1,
+    targetTempoBpm: 80,
+    freshnessState: 'incomplete' as FreshnessState,
+    lastCompletionDate: null,
+    ...overrides,
+  };
+}
+
+function makeRow(overrides: Partial<GridRowProps> = {}): GridRowProps {
+  return {
+    rowId: 'row-1',
+    piece: { title: 'Clair de Lune', composer: 'Debussy' },
+    passageLabel: 'A section',
+    startMeasure: 1,
+    endMeasure: 16,
+    priority: 'HIGH',
+    cells: [
+      makeCell({ cellId: 'cell-1', stepNumber: 1, targetTempoBpm: 80 }),
+      makeCell({ cellId: 'cell-2', stepNumber: 2, targetTempoBpm: 100 }),
+    ],
+    onComplete: vi.fn(),
+    onUndo: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderInTable(props: GridRowProps) {
+  return render(
+    <table>
+      <tbody>
+        <GridRow {...props} />
+      </tbody>
+    </table>,
+  );
+}
+
+describe('GridRow', () => {
+  describe('row header label', () => {
+    it('renders piece title + passageLabel when both present', () => {
+      renderInTable(makeRow({
+        piece: { title: 'Clair de Lune', composer: 'Debussy' },
+        passageLabel: 'A section',
+      }));
+      expect(screen.getByText('Clair de Lune — A section')).toBeInTheDocument();
+    });
+
+    it('renders piece title only when no passageLabel', () => {
+      renderInTable(makeRow({
+        piece: { title: 'Clair de Lune', composer: 'Debussy' },
+        passageLabel: null,
+      }));
+      expect(screen.getByText('Clair de Lune')).toBeInTheDocument();
+    });
+
+    it('renders passageLabel only when no piece', () => {
+      renderInTable(makeRow({
+        piece: null,
+        passageLabel: 'Bridge',
+      }));
+      expect(screen.getByText('Bridge')).toBeInTheDocument();
+    });
+
+    it('renders "Untitled" when neither piece nor passageLabel', () => {
+      renderInTable(makeRow({
+        piece: null,
+        passageLabel: null,
+      }));
+      expect(screen.getByText('Untitled')).toBeInTheDocument();
+    });
+  });
+
+  describe('measures and priority', () => {
+    it('renders measure range and priority', () => {
+      renderInTable(makeRow({ startMeasure: 1, endMeasure: 16, priority: 'HIGH' }));
+      expect(screen.getByText(/mm\. 1–16/)).toBeInTheDocument();
+      expect(screen.getByText('HIGH')).toBeInTheDocument();
+    });
+
+    it('renders HIGH priority in correct color', () => {
+      renderInTable(makeRow({ priority: 'HIGH' }));
+      const priorityEl = screen.getByText('HIGH');
+      expect(priorityEl).toHaveStyle({ color: '#fbbf24' });
+    });
+
+    it('renders CRITICAL priority in correct color', () => {
+      renderInTable(makeRow({ priority: 'CRITICAL' }));
+      const priorityEl = screen.getByText('CRITICAL');
+      expect(priorityEl).toHaveStyle({ color: '#ef4444' });
+    });
+
+    it('renders MEDIUM priority in correct color', () => {
+      renderInTable(makeRow({ priority: 'MEDIUM' }));
+      const priorityEl = screen.getByText('MEDIUM');
+      expect(priorityEl).toHaveStyle({ color: '#9ca3af' });
+    });
+
+    it('renders LOW priority in correct color', () => {
+      renderInTable(makeRow({ priority: 'LOW' }));
+      const priorityEl = screen.getByText('LOW');
+      expect(priorityEl).toHaveStyle({ color: '#9ca3af' });
+    });
+  });
+
+  describe('cells', () => {
+    it('renders correct number of cells', () => {
+      renderInTable(makeRow({
+        cells: [
+          makeCell({ cellId: 'c1' }),
+          makeCell({ cellId: 'c2' }),
+          makeCell({ cellId: 'c3' }),
+        ],
+      }));
+      // 1 header td + 3 cell tds = 3 buttons
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(3);
+    });
+  });
+
+  describe('callback binding', () => {
+    it('binds rowId to onComplete callback', async () => {
+      const user = userEvent.setup();
+      const onComplete = vi.fn();
+      renderInTable(makeRow({ rowId: 'row-42', onComplete }));
+      const buttons = screen.getAllByRole('button');
+      await user.click(buttons[0]);
+      expect(onComplete).toHaveBeenCalledWith('row-42', 'cell-1');
+    });
+
+    it('binds rowId to onUndo callback', () => {
+      const onUndo = vi.fn();
+      renderInTable(makeRow({ rowId: 'row-42', onUndo }));
+      const buttons = screen.getAllByRole('button');
+      fireEvent.contextMenu(buttons[0]);
+      expect(onUndo).toHaveBeenCalledWith('row-42', 'cell-1');
+    });
+  });
+
+  describe('DOM structure', () => {
+    it('renders as a tr element', () => {
+      const { container } = renderInTable(makeRow());
+      const rows = container.querySelectorAll('tr');
+      // table > tbody > tr (our row)
+      expect(rows.length).toBe(1);
+    });
+  });
+});

--- a/tests/unit/components/presentation/GridTable.test.tsx
+++ b/tests/unit/components/presentation/GridTable.test.tsx
@@ -53,7 +53,7 @@ describe('GridTable', () => {
   it('renders helper legend text', () => {
     render(<GridTable {...makeTable()} />);
     expect(screen.getByText(/Click to complete/)).toBeInTheDocument();
-    expect(screen.getByText(/Right-click to undo/)).toBeInTheDocument();
+    expect(screen.getByText(/Right-click or Delete key to undo/)).toBeInTheDocument();
   });
 
   it('scrollable container has overflow-x: auto', () => {
@@ -70,6 +70,11 @@ describe('GridTable', () => {
     const buttons = screen.getAllByRole('button');
     await user.click(buttons[0]);
     expect(onComplete).toHaveBeenCalledWith('row-1', 'row-1-c1');
+  });
+
+  it('table has aria-label for accessibility', () => {
+    render(<GridTable {...makeTable()} />);
+    expect(screen.getByRole('table')).toHaveAttribute('aria-label', 'Practice grid');
   });
 
   it('renders with zero rows', () => {

--- a/tests/unit/components/presentation/GridTable.test.tsx
+++ b/tests/unit/components/presentation/GridTable.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { GridTable, type GridTableProps } from '@/components/presentation/GridTable';
+import type { FreshnessState } from '@/models/freshness';
+
+afterEach(() => cleanup());
+
+function makeCell(id: string, step: number) {
+  return {
+    cellId: id,
+    stepNumber: step,
+    targetTempoBpm: 80,
+    freshnessState: 'incomplete' as FreshnessState,
+    lastCompletionDate: null,
+  };
+}
+
+function makeRowData(id: string, title: string) {
+  return {
+    rowId: id,
+    piece: { title, composer: null },
+    passageLabel: null,
+    startMeasure: 1,
+    endMeasure: 8,
+    priority: 'MEDIUM',
+    cells: [makeCell(`${id}-c1`, 1), makeCell(`${id}-c2`, 2)],
+  };
+}
+
+function makeTable(overrides: Partial<GridTableProps> = {}): GridTableProps {
+  return {
+    rows: [
+      makeRowData('row-1', 'Piece A'),
+      makeRowData('row-2', 'Piece B'),
+      makeRowData('row-3', 'Piece C'),
+    ],
+    onComplete: vi.fn(),
+    onUndo: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('GridTable', () => {
+  it('renders the correct number of rows', () => {
+    render(<GridTable {...makeTable()} />);
+    // Each row renders a tr with buttons
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('renders helper legend text', () => {
+    render(<GridTable {...makeTable()} />);
+    expect(screen.getByText(/Click to complete/)).toBeInTheDocument();
+    expect(screen.getByText(/Right-click to undo/)).toBeInTheDocument();
+  });
+
+  it('scrollable container has overflow-x: auto', () => {
+    const { container } = render(<GridTable {...makeTable()} />);
+    const scrollDiv = container.firstElementChild as HTMLElement;
+    expect(scrollDiv).toHaveStyle({ overflowX: 'auto' });
+  });
+
+  it('passes onComplete to rows with rowId binding', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<GridTable {...makeTable({ onComplete })} />);
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(onComplete).toHaveBeenCalledWith('row-1', 'row-1-c1');
+  });
+
+  it('renders with zero rows', () => {
+    render(<GridTable {...makeTable({ rows: [] })} />);
+    expect(screen.getByText(/Click to complete/)).toBeInTheDocument();
+    expect(screen.queryAllByRole('row')).toHaveLength(0);
+  });
+});

--- a/tests/unit/components/presentation/PracticeCell.test.tsx
+++ b/tests/unit/components/presentation/PracticeCell.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+
+afterEach(() => cleanup());
+import { PracticeCell, type PracticeCellProps } from '@/components/presentation/PracticeCell';
+
+function makeCell(overrides: Partial<PracticeCellProps> = {}): PracticeCellProps {
+  return {
+    cellId: 'cell-1',
+    stepNumber: 3,
+    targetTempoBpm: 106,
+    freshnessState: 'incomplete',
+    lastCompletionDate: null,
+    onComplete: vi.fn(),
+    onUndo: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderInTable(props: PracticeCellProps) {
+  return render(
+    <table>
+      <tbody>
+        <tr>
+          <PracticeCell {...props} />
+        </tr>
+      </tbody>
+    </table>,
+  );
+}
+
+describe('PracticeCell', () => {
+  describe('freshness state rendering', () => {
+    it('renders incomplete state with BPM text and correct colors', () => {
+      renderInTable(makeCell({ freshnessState: 'incomplete', targetTempoBpm: 106 }));
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('106');
+      expect(button).toHaveStyle({ backgroundColor: '#1f2937', color: '#9ca3af' });
+    });
+
+    it('renders fresh state with date and correct colors', () => {
+      renderInTable(makeCell({ freshnessState: 'fresh', lastCompletionDate: '2026-03-15' }));
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('3-15');
+      expect(button).toHaveStyle({ backgroundColor: '#10b981', color: '#ffffff' });
+    });
+
+    it('renders aging state with date and correct colors', () => {
+      renderInTable(makeCell({ freshnessState: 'aging', lastCompletionDate: '2026-03-10' }));
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('3-10');
+      expect(button).toHaveStyle({ backgroundColor: '#6ee7b7', color: '#064e3b' });
+    });
+
+    it('renders stale state with date and correct colors', () => {
+      renderInTable(makeCell({ freshnessState: 'stale', lastCompletionDate: '2026-02-28' }));
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('2-28');
+      expect(button).toHaveStyle({ backgroundColor: '#a7f3d0', color: '#064e3b' });
+    });
+
+    it('renders decayed state with BPM text and correct colors', () => {
+      renderInTable(makeCell({ freshnessState: 'decayed', targetTempoBpm: 80, lastCompletionDate: '2026-01-01' }));
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('80');
+      expect(button).toHaveStyle({ backgroundColor: '#1f2937', color: '#9ca3af' });
+    });
+  });
+
+  describe('date formatting', () => {
+    it('strips leading zeros from month', () => {
+      renderInTable(makeCell({ freshnessState: 'fresh', lastCompletionDate: '2026-03-15' }));
+      expect(screen.getByRole('button')).toHaveTextContent('3-15');
+    });
+
+    it('strips leading zeros from day', () => {
+      renderInTable(makeCell({ freshnessState: 'fresh', lastCompletionDate: '2026-09-05' }));
+      expect(screen.getByRole('button')).toHaveTextContent('9-05');
+    });
+
+    it('formats double-digit month and day correctly', () => {
+      renderInTable(makeCell({ freshnessState: 'fresh', lastCompletionDate: '2026-12-25' }));
+      expect(screen.getByRole('button')).toHaveTextContent('12-25');
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onComplete with cellId on click', async () => {
+      const user = userEvent.setup();
+      const onComplete = vi.fn();
+      renderInTable(makeCell({ cellId: 'cell-42', onComplete }));
+      await user.click(screen.getByRole('button'));
+      expect(onComplete).toHaveBeenCalledWith('cell-42');
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onUndo with cellId on right-click', async () => {
+      const onUndo = vi.fn();
+      renderInTable(makeCell({ cellId: 'cell-42', onUndo }));
+      const button = screen.getByRole('button');
+      // Use fireEvent for contextmenu since userEvent doesn't have right-click
+      const { fireEvent } = await import('@testing-library/react');
+      fireEvent.contextMenu(button);
+      expect(onUndo).toHaveBeenCalledWith('cell-42');
+      expect(onUndo).toHaveBeenCalledTimes(1);
+    });
+
+    it('prevents default on right-click', () => {
+      renderInTable(makeCell());
+      const button = screen.getByRole('button');
+      const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+      const prevented = !button.dispatchEvent(event);
+      expect(prevented).toBe(true);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('renders a semantic button element', () => {
+      renderInTable(makeCell());
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('has correct aria-label for incomplete cell', () => {
+      renderInTable(makeCell({ stepNumber: 3, targetTempoBpm: 106, freshnessState: 'incomplete' }));
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Complete step 3 at 106 BPM',
+      );
+    });
+
+    it('has correct aria-label for completed cell', () => {
+      renderInTable(makeCell({ stepNumber: 2, freshnessState: 'fresh', lastCompletionDate: '2026-03-15' }));
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Undo step 2, completed 3-15',
+      );
+    });
+
+    it('has correct aria-label for decayed cell (shows undo label)', () => {
+      renderInTable(makeCell({ stepNumber: 4, freshnessState: 'decayed', lastCompletionDate: '2026-01-01' }));
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Undo step 4, completed 1-01',
+      );
+    });
+
+    it('is keyboard focusable', () => {
+      renderInTable(makeCell());
+      const button = screen.getByRole('button');
+      button.focus();
+      expect(button).toHaveFocus();
+    });
+
+    it('triggers on Enter key', async () => {
+      const user = userEvent.setup();
+      const onComplete = vi.fn();
+      renderInTable(makeCell({ onComplete, cellId: 'cell-99' }));
+      const button = screen.getByRole('button');
+      button.focus();
+      await user.keyboard('{Enter}');
+      expect(onComplete).toHaveBeenCalledWith('cell-99');
+    });
+
+    it('does not suppress visible focus indicator', () => {
+      renderInTable(makeCell());
+      const button = screen.getByRole('button');
+      // Verify no outline:none or outline:0 in inline styles
+      const style = button.getAttribute('style') || '';
+      expect(style).not.toMatch(/outline\s*:\s*none/);
+      expect(style).not.toMatch(/outline\s*:\s*0/);
+    });
+  });
+
+  describe('DOM structure', () => {
+    it('renders button inside td', () => {
+      renderInTable(makeCell());
+      const button = screen.getByRole('button');
+      expect(button.parentElement?.tagName).toBe('TD');
+    });
+  });
+});

--- a/tests/unit/components/presentation/PracticeCell.test.tsx
+++ b/tests/unit/components/presentation/PracticeCell.test.tsx
@@ -79,7 +79,7 @@ describe('PracticeCell', () => {
 
     it('strips leading zeros from day', () => {
       renderInTable(makeCell({ freshnessState: 'fresh', lastCompletionDate: '2026-09-05' }));
-      expect(screen.getByRole('button')).toHaveTextContent('9-05');
+      expect(screen.getByRole('button')).toHaveTextContent('9-5');
     });
 
     it('formats double-digit month and day correctly', () => {
@@ -140,11 +140,11 @@ describe('PracticeCell', () => {
       );
     });
 
-    it('has correct aria-label for decayed cell (shows undo label)', () => {
-      renderInTable(makeCell({ stepNumber: 4, freshnessState: 'decayed', lastCompletionDate: '2026-01-01' }));
+    it('has correct aria-label for decayed cell (shows complete label, same as incomplete)', () => {
+      renderInTable(makeCell({ stepNumber: 4, freshnessState: 'decayed', targetTempoBpm: 96, lastCompletionDate: '2026-01-01' }));
       expect(screen.getByRole('button')).toHaveAttribute(
         'aria-label',
-        'Undo step 4, completed 1-01',
+        'Complete step 4 at 96 BPM',
       );
     });
 
@@ -163,6 +163,16 @@ describe('PracticeCell', () => {
       button.focus();
       await user.keyboard('{Enter}');
       expect(onComplete).toHaveBeenCalledWith('cell-99');
+    });
+
+    it('triggers undo on Delete key', async () => {
+      const user = userEvent.setup();
+      const onUndo = vi.fn();
+      renderInTable(makeCell({ onUndo, cellId: 'cell-99' }));
+      const button = screen.getByRole('button');
+      button.focus();
+      await user.keyboard('{Delete}');
+      expect(onUndo).toHaveBeenCalledWith('cell-99');
     });
 
     it('does not suppress visible focus indicator', () => {

--- a/tests/unit/lib/query-client.test.tsx
+++ b/tests/unit/lib/query-client.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryProvider } from '@/lib/query-client';
+
+function TestChild() {
+  const client = useQueryClient();
+  return <div data-testid="child">{client ? 'has-client' : 'no-client'}</div>;
+}
+
+describe('QueryProvider', () => {
+  it('provides a QueryClient to children', () => {
+    render(
+      <QueryProvider>
+        <TestChild />
+      </QueryProvider>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('has-client');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,13 +5,16 @@ import path from 'path';
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'node',
-    include: ['tests/unit/**/*.test.ts', 'tests/integration/**/*.test.ts'],
+    include: ['tests/unit/**/*.test.{ts,tsx}', 'tests/integration/**/*.test.{ts,tsx}'],
     env: {
       DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost:5432/tessitura_test',
     },
     setupFiles: ['tests/setup.ts'],
     fileParallelism: false,
+    environmentMatchGlobs: [
+      ['tests/unit/components/**', 'jsdom'],
+      ['tests/integration/components/**', 'jsdom'],
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
@@ -23,13 +26,8 @@ export default defineConfig({
       },
       include: ['src/**/*.ts', 'src/**/*.tsx'],
       exclude: [
-        // Framework scaffolding — zero logic, pure JSX. Will gain tests when
-        // real UI work begins (M2+). Justified in CLAUDE.md § Coverage Exclusions.
-        'src/app/layout.tsx',
-        'src/app/page.tsx',
+        // CSS file, not executable code.
         'src/app/globals.css',
-        // Empty directories (only .gitkeep) — no code to cover yet.
-        'src/components/**',
         // Prisma auto-generated client — not our code, regenerated on every build.
         'src/generated/**',
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,16 +5,13 @@ import path from 'path';
 export default defineConfig({
   plugins: [react()],
   test: {
+    environment: 'node',
     include: ['tests/unit/**/*.test.{ts,tsx}', 'tests/integration/**/*.test.{ts,tsx}'],
     env: {
       DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost:5432/tessitura_test',
     },
     setupFiles: ['tests/setup.ts'],
     fileParallelism: false,
-    environmentMatchGlobs: [
-      ['tests/unit/components/**', 'jsdom'],
-      ['tests/integration/components/**', 'jsdom'],
-    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

First frontend milestone. Grid detail page with cell completion/undo interactions.

- Grid detail page at `/grids/[id]` with cell completion/undo interactions
- Landing page at `/` with grid list links
- TanStack Query for data fetching with refetch-after-mutate pattern
- Green Fade palette (5 freshness states — green drains away as cells decay)
- Flush-border dark table layout (spreadsheet style, matching original Django app)
- Accessible cells: `<button>` inside `<td>` with `aria-label`, keyboard focus, Delete key for undo
- Fade toggle, progress bar, freshness summary, collapsible header
- Helper legend: "Click to complete / Right-click or Delete key to undo"
- Director/Presentation pattern throughout (GridViewDirector + GridListDirector)

## Acceptance Criteria

### UC-1.6 (Complete Cell)
- Left-click any cell calls POST complete endpoint, grid refetches, cell turns green: `PracticeCell.test.tsx` (click test), `GridViewDirector.test.tsx` (complete endpoint test)

### UC-1.7a (Undo Completion)
- Right-click calls POST undo endpoint, grid refetches: `PracticeCell.test.tsx` (right-click test), `GridViewDirector.test.tsx` (undo endpoint test)
- Delete key also triggers undo: `PracticeCell.test.tsx` (Delete key test)

### UC-1.11 (View Priority)
- Priority badges shown in row header with colored text: `GridRow.test.tsx` (priority color test)

### UC-1.12 (View Practice Grid)
- Grid renders as flush-border table with freshness colors: all presentation component tests
- Progress bar shows server-computed completion %: `GridHeader.test.tsx`
- Freshness summary shows non-zero state counts: `GridHeader.test.tsx`

### Rejection Criteria
- No grid/row CRUD forms (NOT in scope)
- No optimistic updates (refetch-after-mutate only)
- No touch undo gesture (acknowledged M1.6 limitation)

## Test Plan

- [x] Unit tests: PracticeCell (20), GridRow (13), GridTable (6), GridHeader (15), GridList (2) = 56 presentation tests
- [x] Integration tests: GridViewDirector (8), GridListDirector (4) = 12 director tests
- [x] Coverage: 97%+ on all metrics (above 95% threshold)
- [x] E2E tests written: landing page, navigation, complete, undo, fade toggle, not found, screenshot assertions
- [ ] E2E tests need seed data + dev server to validate (run `npx prisma db seed` then `npm run test:e2e`)
- [ ] Manual smoke test with seed data

Generated with [Claude Code](https://claude.com/claude-code)