### PR TITLE
feat: M2.1 Domain Model V2 — Sessions, Goals, Templates, Grid Updates

### DIFF
--- a/prisma/migrations/20260411050344_v2_domain_model/migration.sql
+++ b/prisma/migrations/20260411050344_v2_domain_model/migration.sql
@@ -1,0 +1,88 @@
+-- CreateEnum
+CREATE TYPE "GridType" AS ENUM ('REPERTOIRE', 'TECHNIQUE');
+
+-- CreateEnum
+CREATE TYPE "SessionSource" AS ENUM ('MANUAL', 'INFERRED');
+
+-- CreateEnum
+CREATE TYPE "GoalType" AS ENUM ('DAILY_MINUTES', 'WEEKLY_MINUTES', 'WEEKLY_SESSIONS', 'MONTHLY_GRIDS');
+
+-- CreateEnum
+CREATE TYPE "TierRequired" AS ENUM ('FREE', 'PRO');
+
+-- AlterTable
+ALTER TABLE "practice_grids" ADD COLUMN     "archived" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "grid_type" "GridType" NOT NULL DEFAULT 'REPERTOIRE',
+ADD COLUMN     "source_template_id" UUID;
+
+-- CreateTable
+CREATE TABLE "practice_sessions" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "practice_grid_id" UUID,
+    "session_date" DATE NOT NULL,
+    "duration_minutes" INTEGER NOT NULL,
+    "notes" TEXT,
+    "source" "SessionSource" NOT NULL DEFAULT 'MANUAL',
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "practice_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "practice_goals" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "goal_type" "GoalType" NOT NULL,
+    "target_value" INTEGER NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "practice_goals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "library_templates" (
+    "id" UUID NOT NULL,
+    "title" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "collection" TEXT NOT NULL,
+    "description" TEXT,
+    "instrument_tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "grid_type" "GridType" NOT NULL DEFAULT 'REPERTOIRE',
+    "tier_required" "TierRequired" NOT NULL DEFAULT 'FREE',
+    "grid_data" JSONB NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "library_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "practice_sessions_user_id_session_date_idx" ON "practice_sessions"("user_id", "session_date");
+
+-- CreateIndex
+CREATE INDEX "practice_goals_user_id_idx" ON "practice_goals"("user_id");
+
+-- CreateIndex
+CREATE INDEX "practice_grids_user_id_archived_idx" ON "practice_grids"("user_id", "archived");
+
+-- CreateIndex
+CREATE INDEX "practice_grids_source_template_id_idx" ON "practice_grids"("source_template_id");
+
+-- AddForeignKey
+ALTER TABLE "practice_grids" ADD CONSTRAINT "practice_grids_source_template_id_fkey" FOREIGN KEY ("source_template_id") REFERENCES "library_templates"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "practice_sessions" ADD CONSTRAINT "practice_sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "practice_sessions" ADD CONSTRAINT "practice_sessions_practice_grid_id_fkey" FOREIGN KEY ("practice_grid_id") REFERENCES "practice_grids"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "practice_goals" ADD CONSTRAINT "practice_goals_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,28 @@ enum Priority {
   LOW
 }
 
+enum GridType {
+  REPERTOIRE
+  TECHNIQUE
+}
+
+enum SessionSource {
+  MANUAL
+  INFERRED
+}
+
+enum GoalType {
+  DAILY_MINUTES
+  WEEKLY_MINUTES
+  WEEKLY_SESSIONS
+  MONTHLY_GRIDS
+}
+
+enum TierRequired {
+  FREE
+  PRO
+}
+
 // ── Models ─────────────────────────────────────────────────────────
 
 model User {
@@ -32,26 +54,35 @@ model User {
   updatedAt              DateTime               @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt              DateTime?              @map("deleted_at") @db.Timestamptz
 
-  practiceGrids PracticeGrid[]
-  pieces        Piece[]
-  accounts      Account[]
+  practiceGrids    PracticeGrid[]
+  pieces           Piece[]
+  accounts         Account[]
+  practiceSessions PracticeSession[]
+  practiceGoals    PracticeGoal[]
 
   @@map("users")
 }
 
 model PracticeGrid {
-  id          String    @id @default(uuid()) @db.Uuid
-  userId      String    @map("user_id") @db.Uuid
-  name        String
-  notes       String?
-  fadeEnabled Boolean   @default(true) @map("fade_enabled")
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz
-  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
+  id               String            @id @default(uuid()) @db.Uuid
+  userId           String            @map("user_id") @db.Uuid
+  name             String
+  notes            String?
+  fadeEnabled       Boolean           @default(true) @map("fade_enabled")
+  gridType         GridType          @default(REPERTOIRE) @map("grid_type")
+  archived         Boolean           @default(false)
+  sourceTemplateId String?           @map("source_template_id") @db.Uuid
+  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt        DateTime?         @map("deleted_at") @db.Timestamptz
 
-  user         User          @relation(fields: [userId], references: [id])
-  practiceRows PracticeRow[]
+  user             User              @relation(fields: [userId], references: [id])
+  practiceRows     PracticeRow[]
+  sourceTemplate   LibraryTemplate?  @relation(fields: [sourceTemplateId], references: [id])
+  practiceSessions PracticeSession[]
 
+  @@index([userId, archived])
+  @@index([sourceTemplateId])
   @@map("practice_grids")
 }
 
@@ -150,4 +181,58 @@ model VerificationToken {
 
   @@unique([identifier, token])
   @@map("verification_tokens")
+}
+
+model PracticeSession {
+  id              String        @id @default(uuid()) @db.Uuid
+  userId          String        @map("user_id") @db.Uuid
+  practiceGridId  String?       @map("practice_grid_id") @db.Uuid
+  sessionDate     DateTime      @map("session_date") @db.Date
+  durationMinutes Int           @map("duration_minutes")
+  notes           String?
+  source          SessionSource @default(MANUAL)
+  createdAt       DateTime      @default(now()) @map("created_at") @db.Timestamptz
+  deletedAt       DateTime?     @map("deleted_at") @db.Timestamptz
+
+  user         User          @relation(fields: [userId], references: [id])
+  practiceGrid PracticeGrid? @relation(fields: [practiceGridId], references: [id])
+
+  @@index([userId, sessionDate])
+  @@map("practice_sessions")
+}
+
+model PracticeGoal {
+  id          String    @id @default(uuid()) @db.Uuid
+  userId      String    @map("user_id") @db.Uuid
+  goalType    GoalType  @map("goal_type")
+  targetValue Int       @map("target_value")
+  active      Boolean   @default(true)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@map("practice_goals")
+}
+
+model LibraryTemplate {
+  id             String       @id @default(uuid()) @db.Uuid
+  title          String
+  author         String
+  collection     String
+  description    String?
+  instrumentTags String[]     @default([]) @map("instrument_tags")
+  gridType       GridType     @default(REPERTOIRE) @map("grid_type")
+  tierRequired   TierRequired @default(FREE) @map("tier_required")
+  gridData       Json         @map("grid_data")
+  active         Boolean      @default(true)
+  createdAt      DateTime     @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime     @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt      DateTime?    @map("deleted_at") @db.Timestamptz
+
+  clonedGrids PracticeGrid[]
+
+  @@map("library_templates")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../src/generated/prisma/client';
+import { validateGridData } from '../src/models/template';
 
 async function main() {
   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
@@ -76,6 +77,39 @@ async function main() {
   }
 
   console.log(`Seed grid: ${grid.id} (${grid.name})`);
+
+  // ─── M2.1: Library template fixture ────────────────────────────────────
+  // A single sample template so dev + E2E can exercise the clone flow.
+  // Admin CRUD is out of scope for M2.1 — the seed is the only way templates
+  // enter the system, so we validate gridData up-front to avoid inserting
+  // malformed blobs that would fail when a user tried to clone them.
+  const templateGridData = {
+    rows: [
+      { passageLabel: 'Study #1', startMeasure: 1, endMeasure: 16, targetTempo: 120, steps: 5 },
+      { passageLabel: 'Study #2', startMeasure: 1, endMeasure: 24, targetTempo: 108, steps: 4 },
+      { passageLabel: 'Study #3', startMeasure: 1, endMeasure: 16, targetTempo: 132, steps: 6 },
+    ],
+  };
+  // Throws ValidationError if the blob is malformed — fail-fast at seed time.
+  validateGridData(templateGridData);
+
+  const template = await prisma.libraryTemplate.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000200' },
+    update: {},
+    create: {
+      id: '00000000-0000-0000-0000-000000000200',
+      title: 'Clarke Technical Studies (Selections)',
+      author: 'Herbert L. Clarke',
+      collection: 'Technical Studies for the Cornet',
+      description: 'A curated selection of Clarke Technical Studies for daily trumpet practice.',
+      instrumentTags: ['trumpet', 'cornet', 'brass'],
+      gridType: 'REPERTOIRE',
+      gridData: templateGridData,
+    },
+  });
+
+  console.log(`Seed template: ${template.id} (${template.title})`);
+
   await prisma.$disconnect();
 }
 

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest } from 'next/server';
+import { getGoal, updateGoal, deleteGoal } from '@/controllers/goal';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return getGoal(id);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return updateGoal(id, request);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return deleteGoal(id);
+}

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { createGoal, listGoals } from '@/controllers/goal';
+
+export async function POST(request: NextRequest) {
+  return createGoal(request);
+}
+
+export async function GET(request: NextRequest) {
+  return listGoals(request);
+}

--- a/src/app/api/grids/[id]/route.ts
+++ b/src/app/api/grids/[id]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from 'next/server';
-import { getGrid, deleteGrid } from '@/controllers/grid';
+import { getGrid, deleteGrid, updateGrid } from '@/controllers/grid';
 
 export async function GET(
   _request: NextRequest,
@@ -7,6 +7,14 @@ export async function GET(
 ) {
   const { id } = await params;
   return getGrid(id);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return updateGrid(id, request);
 }
 
 export async function DELETE(

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { getSession, deleteSession } from '@/controllers/session';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return getSession(id);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return deleteSession(id);
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { createSession, listSessions } from '@/controllers/session';
+
+export async function POST(request: NextRequest) {
+  return createSession(request);
+}
+
+export async function GET(request: NextRequest) {
+  return listSessions(request);
+}

--- a/src/app/api/templates/[id]/clone/route.ts
+++ b/src/app/api/templates/[id]/clone/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { cloneTemplate } from '@/controllers/template';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return cloneTemplate(id);
+}

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { getTemplate } from '@/controllers/template';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return getTemplate(id);
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from 'next/server';
+import { listTemplates } from '@/controllers/template';
+
+export async function GET(request: NextRequest) {
+  return listTemplates(request);
+}

--- a/src/controllers/goal.ts
+++ b/src/controllers/goal.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUserId } from '@/lib/auth';
+import { AuthenticationError, ConflictError, ValidationError } from '@/lib/errors';
+import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
+import {
+  createGoal as createGoalModel,
+  listGoals as listGoalsModel,
+  getGoalById,
+  updateGoal as updateGoalModel,
+  deleteGoal as deleteGoalModel,
+} from '@/models/goal';
+import { formatGoal, formatGoalList } from '@/views/goal';
+
+export async function createGoal(request: NextRequest) {
+  try {
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== 'object') {
+      return errorResponse('Request body is required', 'VALIDATION_ERROR', 400);
+    }
+    if (typeof body.goalType !== 'string') {
+      return errorResponse('goalType must be a string', 'VALIDATION_ERROR', 400);
+    }
+    if (typeof body.targetValue !== 'number') {
+      return errorResponse('targetValue must be a number', 'VALIDATION_ERROR', 400);
+    }
+
+    const goal = await createGoalModel(userId, {
+      goalType: body.goalType,
+      targetValue: body.targetValue,
+    });
+
+    return NextResponse.json(formatGoal(goal), { status: 201 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    if (error instanceof ConflictError) {
+      return errorResponse(error.message, 'CONFLICT', 409);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function listGoals(request: NextRequest) {
+  try {
+    const userId = await getCurrentUserId();
+    const all = request.nextUrl.searchParams.get('all') === 'true';
+    const goals = await listGoalsModel(userId, all);
+    return NextResponse.json(formatGoalList(goals));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function getGoal(goalId: string) {
+  try {
+    if (!UUID_REGEX.test(goalId)) {
+      return errorResponse('Invalid goal ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const goal = await getGoalById(goalId, userId);
+    if (!goal) {
+      return errorResponse('Goal not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatGoal(goal));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function updateGoal(goalId: string, request: NextRequest) {
+  try {
+    if (!UUID_REGEX.test(goalId)) {
+      return errorResponse('Invalid goal ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return errorResponse('Request body is required', 'VALIDATION_ERROR', 400);
+    }
+
+    // Per-field type checks mirror the model's rules — clearer error messages
+    // than letting Prisma complain.
+    if ('targetValue' in body && typeof body.targetValue !== 'number') {
+      return errorResponse('targetValue must be a number', 'VALIDATION_ERROR', 400);
+    }
+    if ('active' in body && typeof body.active !== 'boolean') {
+      return errorResponse('active must be a boolean', 'VALIDATION_ERROR', 400);
+    }
+
+    const goal = await updateGoalModel(goalId, userId, body);
+    if (!goal) {
+      return errorResponse('Goal not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatGoal(goal));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function deleteGoal(goalId: string) {
+  try {
+    if (!UUID_REGEX.test(goalId)) {
+      return errorResponse('Invalid goal ID format', 'VALIDATION_ERROR', 400);
+    }
+    const userId = await getCurrentUserId();
+    const deleted = await deleteGoalModel(goalId, userId);
+    if (!deleted) {
+      return errorResponse('Goal not found', 'NOT_FOUND', 404);
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/controllers/grid.ts
+++ b/src/controllers/grid.ts
@@ -6,11 +6,24 @@ import {
   listGridsWithDetail,
   getGridById,
   deleteGrid as deleteGridModel,
+  updateGrid as updateGridModel,
   updateGridFade,
+  type ArchivedFilter,
+  type GridUpdateInput,
 } from '@/models/grid';
 import { AuthenticationError, ValidationError } from '@/lib/errors';
 import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
 import { formatGrid, formatGridDetail, formatGridList, formatGridSummaryList } from '@/views/grid';
+
+/**
+ * Parses the `archived` query param into the ArchivedFilter union type.
+ * Accepts 'true' | 'false' | 'all'; anything else (or missing) → 'false'
+ * (the default: active grids only).
+ */
+function parseArchivedFilter(value: string | null): ArchivedFilter {
+  if (value === 'true' || value === 'all') return value;
+  return 'false';
+}
 
 export async function createGrid(request: NextRequest) {
   try {
@@ -46,18 +59,85 @@ export async function listGrids(request: NextRequest) {
   try {
     const userId = await getCurrentUserId();
     const detail = request.nextUrl.searchParams.get('detail') === 'true';
+    const archived = parseArchivedFilter(request.nextUrl.searchParams.get('archived'));
 
     if (detail) {
       const now = new Date();
-      const grids = await listGridsWithDetail(userId);
+      const grids = await listGridsWithDetail(userId, archived);
       return NextResponse.json(formatGridSummaryList(grids, now));
     }
 
-    const grids = await listGridsModel(userId);
+    const grids = await listGridsModel(userId, archived);
     return NextResponse.json(formatGridList(grids));
   } catch (error) {
     if (error instanceof AuthenticationError) {
       return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function updateGrid(gridId: string, request: NextRequest) {
+  try {
+    if (!UUID_REGEX.test(gridId)) {
+      return errorResponse('Invalid grid ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const now = new Date();
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== 'object') {
+      return errorResponse('Request body is required', 'VALIDATION_ERROR', 400);
+    }
+
+    // sourceTemplateId is immutable — reject at the HTTP boundary with an
+    // explicit message so the user isn't confused by silently ignored fields.
+    if ('sourceTemplateId' in body) {
+      return errorResponse(
+        'sourceTemplateId is immutable and cannot be changed after creation',
+        'VALIDATION_ERROR',
+        400,
+      );
+    }
+
+    // Per-field type checks — the model throws ValidationError for value-level
+    // rules (empty name, invalid enum), but Prisma is the backstop for type errors.
+    if ('name' in body && typeof body.name !== 'string') {
+      return errorResponse('name must be a string', 'VALIDATION_ERROR', 400);
+    }
+    if ('notes' in body && body.notes !== null && typeof body.notes !== 'string') {
+      return errorResponse('notes must be a string or null', 'VALIDATION_ERROR', 400);
+    }
+    if ('gridType' in body && typeof body.gridType !== 'string') {
+      return errorResponse('gridType must be a string', 'VALIDATION_ERROR', 400);
+    }
+    if ('archived' in body && typeof body.archived !== 'boolean') {
+      return errorResponse('archived must be a boolean', 'VALIDATION_ERROR', 400);
+    }
+    if ('fadeEnabled' in body && typeof body.fadeEnabled !== 'boolean') {
+      return errorResponse('fadeEnabled must be a boolean', 'VALIDATION_ERROR', 400);
+    }
+
+    const input: GridUpdateInput = {};
+    if ('name' in body) input.name = body.name;
+    if ('notes' in body) input.notes = body.notes;
+    if ('gridType' in body) input.gridType = body.gridType;
+    if ('archived' in body) input.archived = body.archived;
+    if ('fadeEnabled' in body) input.fadeEnabled = body.fadeEnabled;
+
+    const grid = await updateGridModel(gridId, userId, input);
+    if (!grid) {
+      return errorResponse('Grid not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(formatGridDetail(grid, now));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
     }
     return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
   }

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUserId } from '@/lib/auth';
+import { AuthenticationError, ValidationError } from '@/lib/errors';
+import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
+import {
+  createSession as createSessionModel,
+  listSessions as listSessionsModel,
+  getSessionById,
+  deleteSession as deleteSessionModel,
+} from '@/models/session';
+import { formatSession, formatSessionList } from '@/views/session';
+
+export async function createSession(request: NextRequest) {
+  try {
+    const userId = await getCurrentUserId();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== 'object') {
+      return errorResponse('Request body is required', 'VALIDATION_ERROR', 400);
+    }
+
+    // Per-field type checks — model throws ValidationError on value-level rules,
+    // but we reject obvious type mismatches early for clearer messages.
+    if (typeof body.sessionDate !== 'string') {
+      return errorResponse('sessionDate must be a YYYY-MM-DD string', 'VALIDATION_ERROR', 400);
+    }
+    if (typeof body.durationMinutes !== 'number') {
+      return errorResponse('durationMinutes must be a number', 'VALIDATION_ERROR', 400);
+    }
+    if (body.notes != null && typeof body.notes !== 'string') {
+      return errorResponse('notes must be a string', 'VALIDATION_ERROR', 400);
+    }
+    if (body.practiceGridId != null && typeof body.practiceGridId !== 'string') {
+      return errorResponse('practiceGridId must be a string', 'VALIDATION_ERROR', 400);
+    }
+
+    const session = await createSessionModel(userId, {
+      sessionDate: body.sessionDate,
+      durationMinutes: body.durationMinutes,
+      notes: body.notes ?? null,
+      practiceGridId: body.practiceGridId ?? null,
+    });
+
+    return NextResponse.json(formatSession(session), { status: 201 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function listSessions(request: NextRequest) {
+  try {
+    const userId = await getCurrentUserId();
+    const from = request.nextUrl.searchParams.get('from');
+    const to = request.nextUrl.searchParams.get('to');
+
+    const sessions = await listSessionsModel(userId, from, to);
+    return NextResponse.json(formatSessionList(sessions));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function getSession(sessionId: string) {
+  try {
+    if (!UUID_REGEX.test(sessionId)) {
+      return errorResponse('Invalid session ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const userId = await getCurrentUserId();
+    const session = await getSessionById(sessionId, userId);
+
+    if (!session) {
+      return errorResponse('Session not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(formatSession(session));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function deleteSession(sessionId: string) {
+  try {
+    if (!UUID_REGEX.test(sessionId)) {
+      return errorResponse('Invalid session ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const userId = await getCurrentUserId();
+    const deleted = await deleteSessionModel(sessionId, userId);
+
+    if (!deleted) {
+      return errorResponse('Session not found', 'NOT_FOUND', 404);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/controllers/template.ts
+++ b/src/controllers/template.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUserId } from '@/lib/auth';
+import { AuthenticationError, ValidationError } from '@/lib/errors';
+import { UUID_REGEX, errorResponse } from '@/lib/api-helpers';
+import {
+  listTemplates as listTemplatesModel,
+  getTemplateById,
+  cloneTemplate as cloneTemplateModel,
+} from '@/models/template';
+import { getGridById } from '@/models/grid';
+import { formatTemplateDetail, formatTemplateList } from '@/views/template';
+import { formatGridDetail } from '@/views/grid';
+
+export async function listTemplates(request: NextRequest) {
+  try {
+    // Auth required for all template endpoints in M2.1, per spec — simplifies
+    // the threat model and is consistent with the rest of the API. Once the
+    // public catalog is built (V4+), list/detail can drop auth.
+    await getCurrentUserId();
+    const instrument = request.nextUrl.searchParams.get('instrument');
+    const templates = await listTemplatesModel(instrument);
+    return NextResponse.json(formatTemplateList(templates));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function getTemplate(templateId: string) {
+  try {
+    if (!UUID_REGEX.test(templateId)) {
+      return errorResponse('Invalid template ID format', 'VALIDATION_ERROR', 400);
+    }
+    await getCurrentUserId();
+    const template = await getTemplateById(templateId);
+    if (!template) {
+      return errorResponse('Template not found', 'NOT_FOUND', 404);
+    }
+    return NextResponse.json(formatTemplateDetail(template));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}
+
+export async function cloneTemplate(templateId: string) {
+  try {
+    if (!UUID_REGEX.test(templateId)) {
+      return errorResponse('Invalid template ID format', 'VALIDATION_ERROR', 400);
+    }
+
+    const now = new Date();
+    const userId = await getCurrentUserId();
+    const result = await cloneTemplateModel(templateId, userId);
+
+    if (result === 'not-found') {
+      return errorResponse('Template not found', 'NOT_FOUND', 404);
+    }
+
+    // Fetch the newly created grid with full detail so the client can
+    // immediately render it. Owned lookup is guaranteed to succeed here
+    // because we just created it under this user in the same request.
+    const grid = await getGridById(result, userId);
+    /* v8 ignore next 3 -- grid was just created in this request; cannot be null */
+    if (!grid) {
+      return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+    }
+
+    return NextResponse.json(formatGridDetail(grid, now), { status: 201 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return errorResponse(error.message, 'AUTHENTICATION_ERROR', 401);
+    }
+    if (error instanceof ValidationError) {
+      return errorResponse(error.message, 'VALIDATION_ERROR', 400);
+    }
+    return errorResponse('Internal server error', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -15,6 +15,8 @@ function createExtendedClient() {
   const SOFT_DELETE_MODELS = new Set([
     'User', 'PracticeGrid', 'PracticeRow', 'PracticeCell',
     'PracticeCellCompletion', 'Piece',
+    // V2 additions (M2.1):
+    'PracticeSession', 'PracticeGoal', 'LibraryTemplate',
   ]);
 
   return base.$extends({

--- a/src/models/goal.ts
+++ b/src/models/goal.ts
@@ -1,0 +1,170 @@
+import { prisma } from '@/lib/db';
+import { ConflictError, ValidationError } from '@/lib/errors';
+
+/**
+ * Valid goalType enum values — kept in sync with the Prisma GoalType enum.
+ * Declared here so validation can run without importing the generated client.
+ */
+const GOAL_TYPES = ['DAILY_MINUTES', 'WEEKLY_MINUTES', 'WEEKLY_SESSIONS', 'MONTHLY_GRIDS'] as const;
+type GoalType = (typeof GOAL_TYPES)[number];
+
+function isGoalType(value: unknown): value is GoalType {
+  return typeof value === 'string' && (GOAL_TYPES as readonly string[]).includes(value);
+}
+
+export interface GoalInput {
+  goalType: string;
+  targetValue: number;
+}
+
+export interface ValidatedGoalInput {
+  goalType: GoalType;
+  targetValue: number;
+}
+
+export interface GoalUpdateInput {
+  targetValue?: number;
+  active?: boolean;
+}
+
+export interface ValidatedGoalUpdate {
+  targetValue?: number;
+  active?: boolean;
+}
+
+function validateTargetValue(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 10000) {
+    throw new ValidationError('targetValue must be an integer between 1 and 10000');
+  }
+  return value;
+}
+
+/**
+ * Validates a PracticeGoal create payload. Pure function — no DB access.
+ */
+export function validateGoalInput(input: GoalInput): ValidatedGoalInput {
+  if (!isGoalType(input?.goalType)) {
+    throw new ValidationError(
+      `goalType must be one of: ${GOAL_TYPES.join(', ')}`,
+    );
+  }
+  const targetValue = validateTargetValue(input.targetValue);
+  return { goalType: input.goalType, targetValue };
+}
+
+/**
+ * Validates a PracticeGoal update payload. Pure function — no DB access.
+ *
+ * `goalType` is explicitly rejected: the measurement unit is immutable after
+ * creation (user must deactivate + re-create to change units). The error
+ * message is user-facing and must contain "goalType" + "cannot be changed"
+ * for the integration tests.
+ */
+export function validateGoalUpdate(input: GoalUpdateInput): ValidatedGoalUpdate {
+  if ('goalType' in (input as object)) {
+    throw new ValidationError('goalType cannot be changed after creation');
+  }
+
+  const result: ValidatedGoalUpdate = {};
+  if (input.targetValue !== undefined) {
+    result.targetValue = validateTargetValue(input.targetValue);
+  }
+  if (input.active !== undefined) {
+    if (typeof input.active !== 'boolean') {
+      throw new ValidationError('active must be a boolean');
+    }
+    result.active = input.active;
+  }
+  return result;
+}
+
+/**
+ * Scopes a findFirst to the given goal + user. Query-driven ownership.
+ */
+async function findOwnedGoal(goalId: string, userId: string) {
+  return prisma.practiceGoal.findFirst({
+    where: { id: goalId, userId, deletedAt: null },
+  });
+}
+
+/**
+ * Creates a PracticeGoal. Enforces the "one active goal per goalType" rule:
+ * if an active goal of the same type already exists, throws ConflictError
+ * (controller returns 409). The user must deactivate the existing goal
+ * before creating a new one with the same goalType.
+ *
+ * Inactive goals of the same type are unlimited — they are historical records.
+ */
+export async function createGoal(userId: string, input: GoalInput) {
+  const validated = validateGoalInput(input);
+
+  const existing = await prisma.practiceGoal.findFirst({
+    where: {
+      userId,
+      goalType: validated.goalType,
+      active: true,
+      deletedAt: null,
+    },
+  });
+  if (existing) {
+    throw new ConflictError(
+      `An active goal of type ${validated.goalType} already exists. Deactivate it before creating a new one.`,
+    );
+  }
+
+  return prisma.practiceGoal.create({
+    data: {
+      userId,
+      goalType: validated.goalType,
+      targetValue: validated.targetValue,
+      active: true,
+    },
+  });
+}
+
+/**
+ * Lists goals for a user. Default: active only. Pass `all: true` to include
+ * inactive historical goals as well. Sorted by createdAt desc.
+ */
+export async function listGoals(userId: string, all = false) {
+  return prisma.practiceGoal.findMany({
+    where: {
+      userId,
+      deletedAt: null,
+      ...(all ? {} : { active: true }),
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function getGoalById(goalId: string, userId: string) {
+  return findOwnedGoal(goalId, userId);
+}
+
+/**
+ * Updates a goal's targetValue and/or active flag. Throws ValidationError
+ * if the caller tries to change goalType.
+ */
+export async function updateGoal(goalId: string, userId: string, input: GoalUpdateInput) {
+  const goal = await findOwnedGoal(goalId, userId);
+  if (!goal) return null;
+
+  const validated = validateGoalUpdate(input);
+  if (Object.keys(validated).length === 0) return goal;
+
+  return prisma.practiceGoal.update({
+    where: { id: goalId },
+    data: validated,
+  });
+}
+
+/**
+ * Soft-deletes a goal via the extension-backed delete interceptor.
+ */
+export async function deleteGoal(goalId: string, userId: string): Promise<boolean> {
+  const goal = await findOwnedGoal(goalId, userId);
+  if (!goal) return false;
+
+  await prisma.practiceGoal.delete({ where: { id: goalId } });
+  return true;
+}

--- a/src/models/grid.ts
+++ b/src/models/grid.ts
@@ -12,6 +12,33 @@ export interface ValidatedGridInput {
 }
 
 /**
+ * Fields accepted by `updateGrid`. `sourceTemplateId` is deliberately absent —
+ * it is set once during clone and is immutable afterward. The controller
+ * rejects it at the HTTP boundary; the model's type guarantees it can't leak
+ * through via Object.assign-style spreading.
+ */
+export interface GridUpdateInput {
+  name?: string;
+  notes?: string | null;
+  gridType?: string;
+  archived?: boolean;
+  fadeEnabled?: boolean;
+}
+
+/**
+ * Possible values for the `archived` list-filter:
+ * - 'false' (default): only non-archived grids
+ * - 'true': only archived grids
+ * - 'all': both
+ */
+export type ArchivedFilter = 'true' | 'false' | 'all';
+
+function archivedWhere(filter: ArchivedFilter): { archived?: boolean } {
+  if (filter === 'all') return {};
+  return { archived: filter === 'true' };
+}
+
+/**
  * Validates and normalizes grid input.
  * Pure function — no database access.
  */
@@ -55,10 +82,13 @@ export async function createGrid(userId: string, input: GridInput) {
 
 /**
  * Lists all grids for a user, sorted by updatedAt descending.
+ * The `archived` filter defaults to 'false' (active grids only) to match
+ * the API spec — archived grids are hidden from list views by default and
+ * only surface with ?archived=true or ?archived=all.
  */
-export async function listGrids(userId: string) {
+export async function listGrids(userId: string, archived: ArchivedFilter = 'false') {
   return prisma.practiceGrid.findMany({
-    where: { userId, deletedAt: null },
+    where: { userId, deletedAt: null, ...archivedWhere(archived) },
     orderBy: { updatedAt: 'desc' },
   });
 }
@@ -123,19 +153,65 @@ export async function getGridById(gridId: string, userId: string) {
 }
 
 /**
- * Updates the fadeEnabled flag on a grid.
- * Returns the full grid detail (via getGridById), or null if not found/not owned.
+ * Updates one or more fields on a grid. Returns the full grid detail (via
+ * getGridById), or null if not found/not owned. Throws ValidationError if
+ * any input field is invalid.
+ *
+ * `sourceTemplateId` cannot be changed — it is set once during clone and
+ * must not leak through update paths. The controller layer also rejects it
+ * at the HTTP boundary so the user gets a clear 400 with an explicit
+ * message rather than a silently ignored field.
+ *
+ * `name` re-uses validateGridInput so the same trim / length / empty-string
+ * rules apply to updates as to creates.
+ *
+ * `notes` is independently updatable: null or empty string normalizes to
+ * null; whitespace is trimmed; max 2000 chars enforced.
  */
-export async function updateGridFade(gridId: string, userId: string, fadeEnabled: boolean) {
+export async function updateGrid(gridId: string, userId: string, input: GridUpdateInput) {
   const grid = await findOwnedGrid(gridId, userId);
   if (!grid) return null;
 
-  await prisma.practiceGrid.update({
-    where: { id: gridId },
-    data: { fadeEnabled },
-  });
+  const data: Record<string, unknown> = {};
 
+  if (input.name !== undefined) {
+    // validateGridInput requires name; pass through current notes if no notes update
+    const currentNotes = input.notes !== undefined ? input.notes : grid.notes;
+    const validated = validateGridInput({ name: input.name, notes: currentNotes });
+    data.name = validated.name;
+    if (input.notes !== undefined) data.notes = validated.notes;
+  } else if (input.notes !== undefined) {
+    const trimmed = input.notes?.trim() ?? null;
+    const normalized = trimmed === '' ? null : trimmed;
+    if (normalized && normalized.length > 2000) {
+      throw new ValidationError('Grid notes must be 2000 characters or less');
+    }
+    data.notes = normalized;
+  }
+
+  if (input.gridType !== undefined) {
+    if (input.gridType !== 'REPERTOIRE' && input.gridType !== 'TECHNIQUE') {
+      throw new ValidationError('gridType must be REPERTOIRE or TECHNIQUE');
+    }
+    data.gridType = input.gridType;
+  }
+
+  if (input.archived !== undefined) data.archived = input.archived;
+  if (input.fadeEnabled !== undefined) data.fadeEnabled = input.fadeEnabled;
+
+  if (Object.keys(data).length === 0) return getGridById(gridId, userId);
+
+  await prisma.practiceGrid.update({ where: { id: gridId }, data });
   return getGridById(gridId, userId);
+}
+
+/**
+ * Thin wrapper retained for the legacy /api/grids/{id}/fade endpoint.
+ * All grid updates funnel through `updateGrid` — there is a single code
+ * path for all grid field mutations.
+ */
+export async function updateGridFade(gridId: string, userId: string, fadeEnabled: boolean) {
+  return updateGrid(gridId, userId, { fadeEnabled });
 }
 
 /**
@@ -190,6 +266,7 @@ export async function deleteGrid(gridId: string, userId: string, now: Date): Pro
 /**
  * Lists all grids for a user with full nested data (rows, cells, completions).
  * Same includes as getGridById but for all grids at once in a single query.
+ * Same archived filter semantics as listGrids.
  *
  * Soft-delete visibility rules:
  * - Grids: hidden when soft-deleted (filtered out)
@@ -198,9 +275,9 @@ export async function deleteGrid(gridId: string, userId: string, now: Date): Pro
  * - Completions: hidden when soft-deleted (filtered out)
  * - Piece: ALWAYS shown, even if the piece itself is soft-deleted.
  */
-export async function listGridsWithDetail(userId: string) {
+export async function listGridsWithDetail(userId: string, archived: ArchivedFilter = 'false') {
   return prisma.practiceGrid.findMany({
-    where: { userId, deletedAt: null },
+    where: { userId, deletedAt: null, ...archivedWhere(archived) },
     orderBy: { updatedAt: 'desc' },
     include: GRID_DETAIL_INCLUDE,
   });

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -1,0 +1,199 @@
+import { prisma } from '@/lib/db';
+import { ValidationError } from '@/lib/errors';
+import { UUID_REGEX } from '@/lib/api-helpers';
+import { findOwnedGrid } from '@/models/grid';
+
+/**
+ * Input shape for a manual PracticeSession create.
+ *
+ * `sessionDate` is always a YYYY-MM-DD **string** — this is a calendar date,
+ * not a moment in time, and no timezone conversion is done anywhere in the
+ * stack. Same convention as `PracticeCellCompletion.completionDate`.
+ */
+export interface SessionInput {
+  sessionDate: string;
+  durationMinutes: number;
+  notes?: string | null;
+  practiceGridId?: string | null;
+}
+
+export interface ValidatedSessionInput {
+  sessionDate: string;
+  durationMinutes: number;
+  notes: string | null;
+  practiceGridId: string | null;
+}
+
+/**
+ * Strict YYYY-MM-DD pattern. Rejects `2026-4-1` (short zero-padding),
+ * `2026/04/01` (wrong separators), and any other non-canonical form.
+ */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Validates a YYYY-MM-DD string. In addition to the regex, we re-parse the
+ * components to catch logically invalid dates like `2026-13-01` or `2026-04-32`
+ * — the regex alone would pass those.
+ */
+function validateDateOnlyString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !DATE_RE.test(value)) {
+    throw new ValidationError(`${fieldName} must be a YYYY-MM-DD string`);
+  }
+  const [yearStr, monthStr, dayStr] = value.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if (month < 1 || month > 12) {
+    throw new ValidationError(`${fieldName} month must be between 01 and 12`);
+  }
+  // Use Date to validate day-in-month (handles leap years, 30-day months, etc.)
+  // Note: Date constructor uses 0-indexed months; we pass (year, month-1, day) and
+  // verify the round-trip produces the same components.
+  const d = new Date(Date.UTC(year, month - 1, day));
+  if (
+    d.getUTCFullYear() !== year ||
+    d.getUTCMonth() !== month - 1 ||
+    d.getUTCDate() !== day
+  ) {
+    throw new ValidationError(`${fieldName} is not a valid calendar date`);
+  }
+  return value;
+}
+
+/**
+ * Validates and normalizes a SessionInput. Pure function — no DB access.
+ *
+ * Rules:
+ * - sessionDate: YYYY-MM-DD string, valid calendar date
+ * - durationMinutes: integer, 1 ≤ d ≤ 1440 (24h)
+ * - notes: optional; whitespace trimmed; empty → null; ≤ 2000 chars
+ * - practiceGridId: optional; if present must be a valid UUID (ownership
+ *   verified separately in createSession, not here)
+ */
+export function validateSessionInput(input: SessionInput): ValidatedSessionInput {
+  const sessionDate = validateDateOnlyString(input?.sessionDate, 'sessionDate');
+
+  const durationMinutes = input?.durationMinutes;
+  if (
+    typeof durationMinutes !== 'number' ||
+    !Number.isInteger(durationMinutes) ||
+    durationMinutes < 1 ||
+    durationMinutes > 1440
+  ) {
+    throw new ValidationError('durationMinutes must be an integer between 1 and 1440');
+  }
+
+  let notes: string | null = null;
+  if (input.notes != null) {
+    if (typeof input.notes !== 'string') {
+      throw new ValidationError('notes must be a string');
+    }
+    const trimmed = input.notes.trim();
+    notes = trimmed === '' ? null : trimmed;
+    if (notes && notes.length > 2000) {
+      throw new ValidationError('notes must be 2000 characters or less');
+    }
+  }
+
+  let practiceGridId: string | null = null;
+  if (input.practiceGridId != null) {
+    if (typeof input.practiceGridId !== 'string' || !UUID_REGEX.test(input.practiceGridId)) {
+      throw new ValidationError('practiceGridId must be a valid UUID');
+    }
+    practiceGridId = input.practiceGridId;
+  }
+
+  return { sessionDate, durationMinutes, notes, practiceGridId };
+}
+
+/**
+ * Scopes a findFirst to the given session + user. Used by getSession and
+ * deleteSession to enforce query-driven ownership (not a post-query check).
+ */
+async function findOwnedSession(sessionId: string, userId: string) {
+  return prisma.practiceSession.findFirst({
+    where: { id: sessionId, userId, deletedAt: null },
+  });
+}
+
+/**
+ * Creates a PracticeSession. Throws ValidationError on invalid input or if
+ * a practiceGridId is provided but the grid is not owned by the user
+ * (grids for other users leak nothing — ownership is checked via query).
+ * Always sets source = MANUAL (INFERRED is reserved for M2.3 inference).
+ */
+export async function createSession(userId: string, input: SessionInput) {
+  const validated = validateSessionInput(input);
+
+  if (validated.practiceGridId) {
+    const owned = await findOwnedGrid(validated.practiceGridId, userId);
+    if (!owned) {
+      throw new ValidationError('practiceGridId references a grid that does not exist or is not owned by this user');
+    }
+  }
+
+  return prisma.practiceSession.create({
+    data: {
+      userId,
+      practiceGridId: validated.practiceGridId,
+      sessionDate: new Date(`${validated.sessionDate}T00:00:00.000Z`),
+      durationMinutes: validated.durationMinutes,
+      notes: validated.notes,
+      source: 'MANUAL',
+    },
+  });
+}
+
+/**
+ * Lists sessions for a user, sorted by sessionDate desc then createdAt desc
+ * so same-day sessions appear newest-first.
+ *
+ * Optional `from`/`to` range filter — both are YYYY-MM-DD strings, both are
+ * inclusive. Validates the date format; throws ValidationError on malformed
+ * input so the controller can return 400.
+ */
+export async function listSessions(userId: string, from?: string | null, to?: string | null) {
+  const where: {
+    userId: string;
+    deletedAt: null;
+    sessionDate?: { gte?: Date; lte?: Date };
+  } = { userId, deletedAt: null };
+
+  if (from != null || to != null) {
+    where.sessionDate = {};
+    if (from != null) {
+      const validated = validateDateOnlyString(from, 'from');
+      where.sessionDate.gte = new Date(`${validated}T00:00:00.000Z`);
+    }
+    if (to != null) {
+      const validated = validateDateOnlyString(to, 'to');
+      where.sessionDate.lte = new Date(`${validated}T00:00:00.000Z`);
+    }
+  }
+
+  return prisma.practiceSession.findMany({
+    where,
+    orderBy: [{ sessionDate: 'desc' }, { createdAt: 'desc' }],
+  });
+}
+
+/**
+ * Gets a session by ID scoped to the user. Returns null if not found or
+ * not owned.
+ */
+export async function getSessionById(sessionId: string, userId: string) {
+  return findOwnedSession(sessionId, userId);
+}
+
+/**
+ * Soft-deletes a session. Returns true if a row was deleted, false if not
+ * found / not owned. Routes through the soft-delete extension, which
+ * intercepts `delete` on allowlisted models and converts to deletedAt update.
+ */
+export async function deleteSession(sessionId: string, userId: string): Promise<boolean> {
+  const session = await findOwnedSession(sessionId, userId);
+  if (!session) return false;
+
+  await prisma.practiceSession.delete({ where: { id: sessionId } });
+  return true;
+}

--- a/src/models/template.ts
+++ b/src/models/template.ts
@@ -1,0 +1,120 @@
+import { prisma } from '@/lib/db';
+import { ValidationError } from '@/lib/errors';
+import { validateRowInput, type RowInput, type ValidatedRowInput } from '@/models/row';
+
+/**
+ * Shape of a LibraryTemplate's `gridData` JSON blob.
+ *
+ * A template's gridData is the single source of truth for how a cloned
+ * PracticeGrid is structured. Each row here maps 1:1 to a PracticeRow on
+ * clone (with pieceId always null — template rows are not linked to a
+ * user's piece library).
+ *
+ * Row fields mirror PracticeRow create inputs: the same numeric bounds
+ * apply (validateRowInput is re-used so the rules can't drift).
+ */
+export interface TemplateGridData {
+  rows: Array<
+    Partial<Pick<RowInput, 'passageLabel'>> & {
+      startMeasure: number;
+      endMeasure: number;
+      targetTempo: number;
+      steps: number;
+    }
+  >;
+}
+
+export interface ValidatedTemplateGridData {
+  rows: ValidatedRowInput[];
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validates a LibraryTemplate gridData JSON blob. Accepts `unknown` because
+ * the blob comes from DB JSON (`Prisma.JsonValue`) which has no static shape.
+ *
+ * Rules:
+ * - `rows` is an array with at least 1 row
+ * - each row validates via `validateRowInput` from src/models/row.ts, so
+ *   numeric bounds (startMeasure/endMeasure/targetTempo/steps) cannot drift
+ *   from PracticeRow creation rules
+ * - `pieceId` is always ignored / forced to null — templates are not tied
+ *   to any user's piece library
+ *
+ * Used in two places:
+ * - `cloneTemplate` before inserting rows
+ * - `prisma/seed.ts` before inserting templates (so seed data stays valid)
+ */
+export function validateGridData(data: unknown): ValidatedTemplateGridData {
+  if (!isObject(data)) {
+    throw new ValidationError('gridData must be an object with a rows array');
+  }
+  if (!Array.isArray(data.rows)) {
+    throw new ValidationError('gridData.rows must be an array');
+  }
+  if (data.rows.length === 0) {
+    throw new ValidationError('gridData.rows must contain at least 1 row');
+  }
+
+  const rows: ValidatedRowInput[] = [];
+  for (let i = 0; i < data.rows.length; i++) {
+    const raw = data.rows[i];
+    if (!isObject(raw)) {
+      throw new ValidationError(`gridData.rows[${i}] must be an object`);
+    }
+    try {
+      // validateRowInput covers numeric bounds, passageLabel length, and
+      // start ≤ end cross-field check. Force pieceId: null — templates
+      // never reference a user's pieces.
+      rows.push(
+        validateRowInput({
+          startMeasure: raw.startMeasure as number,
+          endMeasure: raw.endMeasure as number,
+          targetTempo: raw.targetTempo as number,
+          steps: raw.steps as number,
+          passageLabel: (raw.passageLabel ?? null) as string | null,
+          pieceId: null,
+        }),
+      );
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        throw new ValidationError(`gridData.rows[${i}]: ${err.message}`);
+      }
+      throw err;
+    }
+  }
+
+  return { rows };
+}
+
+/**
+ * Lists active, non-deleted LibraryTemplates. Optional `instrument` filter
+ * matches case-insensitively against any element of `instrumentTags`.
+ *
+ * Postgres arrays don't have a built-in case-insensitive `has` so we query
+ * all active templates and filter in memory after lowercasing. This is fine
+ * at M2.1 scale (≤ dozens of templates). If the catalog grows, swap to a
+ * lowercased array column or a Postgres GIN index with custom expression.
+ */
+export async function listTemplates(instrument?: string | null) {
+  const templates = await prisma.libraryTemplate.findMany({
+    where: { active: true, deletedAt: null },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  if (!instrument) return templates;
+
+  const needle = instrument.toLowerCase();
+  return templates.filter((t) =>
+    t.instrumentTags.some((tag) => tag.toLowerCase().includes(needle)),
+  );
+}
+
+export async function getTemplateById(templateId: string) {
+  return prisma.libraryTemplate.findFirst({
+    where: { id: templateId, active: true, deletedAt: null },
+  });
+}

--- a/src/models/template.ts
+++ b/src/models/template.ts
@@ -1,6 +1,11 @@
 import { prisma } from '@/lib/db';
 import { ValidationError } from '@/lib/errors';
-import { validateRowInput, type RowInput, type ValidatedRowInput } from '@/models/row';
+import {
+  validateRowInput,
+  generateCellPercentages,
+  type RowInput,
+  type ValidatedRowInput,
+} from '@/models/row';
 
 /**
  * Shape of a LibraryTemplate's `gridData` JSON blob.
@@ -116,5 +121,80 @@ export async function listTemplates(instrument?: string | null) {
 export async function getTemplateById(templateId: string) {
   return prisma.libraryTemplate.findFirst({
     where: { id: templateId, active: true, deletedAt: null },
+  });
+}
+
+/**
+ * Clones a LibraryTemplate into a new PracticeGrid owned by the given user.
+ *
+ * The clone is fully transactional — if any row or cell insert fails, the
+ * entire operation rolls back (no partial grid left behind). `gridData` is
+ * validated BEFORE entering the transaction so a 400 failure doesn't even
+ * start a DB transaction.
+ *
+ * Returns:
+ * - the ID of the created grid on success
+ * - `'not-found'` if the template doesn't exist or is inactive
+ * - throws ValidationError for malformed gridData (controller → 400)
+ *
+ * A string literal is used for the "not found" branch instead of null so
+ * the caller can distinguish between "template missing" and "clone failed"
+ * without sentinel arguments.
+ *
+ * Row structure:
+ * - Each gridData row → one PracticeRow with sortOrder = array index
+ * - pieceId is always null (template rows don't link to user pieces)
+ * - passageLabel carries through if present
+ * - Cells generated via generateCellPercentages (same formula as direct
+ *   row creation) so clones behave identically to manual rows
+ */
+export async function cloneTemplate(
+  templateId: string,
+  userId: string,
+): Promise<string | 'not-found'> {
+  const template = await prisma.libraryTemplate.findFirst({
+    where: { id: templateId, active: true, deletedAt: null },
+  });
+  if (!template) return 'not-found';
+
+  const validated = validateGridData(template.gridData);
+
+  return prisma.$transaction(async (tx) => {
+    const grid = await tx.practiceGrid.create({
+      data: {
+        userId,
+        name: template.title,
+        gridType: template.gridType,
+        sourceTemplateId: template.id,
+        fadeEnabled: true,
+      },
+    });
+
+    for (let sortOrder = 0; sortOrder < validated.rows.length; sortOrder++) {
+      const rowData = validated.rows[sortOrder];
+      const row = await tx.practiceRow.create({
+        data: {
+          practiceGridId: grid.id,
+          sortOrder,
+          startMeasure: rowData.startMeasure,
+          endMeasure: rowData.endMeasure,
+          targetTempo: rowData.targetTempo,
+          steps: rowData.steps,
+          passageLabel: rowData.passageLabel,
+          // pieceId intentionally omitted — template rows have no user-piece link
+        },
+      });
+
+      const percentages = generateCellPercentages(rowData.steps);
+      await tx.practiceCell.createMany({
+        data: percentages.map((pct, i) => ({
+          practiceRowId: row.id,
+          stepNumber: i,
+          targetTempoPercentage: pct,
+        })),
+      });
+    }
+
+    return grid.id;
   });
 }

--- a/src/views/goal.ts
+++ b/src/views/goal.ts
@@ -1,0 +1,27 @@
+type GoalType = 'DAILY_MINUTES' | 'WEEKLY_MINUTES' | 'WEEKLY_SESSIONS' | 'MONTHLY_GRIDS';
+
+interface GoalRecord {
+  id: string;
+  userId: string;
+  goalType: GoalType;
+  targetValue: number;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export function formatGoal(goal: GoalRecord) {
+  return {
+    id: goal.id,
+    goalType: goal.goalType,
+    targetValue: goal.targetValue,
+    active: goal.active,
+    createdAt: goal.createdAt.toISOString(),
+    updatedAt: goal.updatedAt.toISOString(),
+  };
+}
+
+export function formatGoalList(goals: GoalRecord[]) {
+  return goals.map(formatGoal);
+}

--- a/src/views/grid.ts
+++ b/src/views/grid.ts
@@ -11,6 +11,9 @@ interface GridRecord {
   name: string;
   notes: string | null;
   fadeEnabled: boolean;
+  gridType: string;
+  archived: boolean;
+  sourceTemplateId: string | null;
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
@@ -26,6 +29,9 @@ export function formatGrid(grid: GridRecord) {
     name: grid.name,
     notes: grid.notes,
     fadeEnabled: grid.fadeEnabled,
+    gridType: grid.gridType,
+    archived: grid.archived,
+    sourceTemplateId: grid.sourceTemplateId,
     createdAt: grid.createdAt.toISOString(),
     updatedAt: grid.updatedAt.toISOString(),
   };

--- a/src/views/session.ts
+++ b/src/views/session.ts
@@ -1,0 +1,44 @@
+/**
+ * PracticeSession response formatting.
+ *
+ * `sessionDate` is stored as `@db.Date` in Prisma (date-only, no time
+ * component) but Prisma returns it as a JavaScript Date — the view layer
+ * is responsible for re-serializing it as a YYYY-MM-DD string at the API
+ * boundary so clients never see a full ISO timestamp for what is semantically
+ * a calendar date.
+ *
+ * Uses `.toISOString().slice(0, 10)` instead of local-date formatting to
+ * stay timezone-independent: the stored date was inserted at UTC midnight,
+ * so the ISO string's first 10 chars are always the intended calendar date
+ * regardless of the server's local time.
+ */
+
+type SessionSource = 'MANUAL' | 'INFERRED';
+
+interface SessionRecord {
+  id: string;
+  userId: string;
+  practiceGridId: string | null;
+  sessionDate: Date;
+  durationMinutes: number;
+  notes: string | null;
+  source: SessionSource;
+  createdAt: Date;
+  deletedAt: Date | null;
+}
+
+export function formatSession(session: SessionRecord) {
+  return {
+    id: session.id,
+    practiceGridId: session.practiceGridId,
+    sessionDate: session.sessionDate.toISOString().slice(0, 10),
+    durationMinutes: session.durationMinutes,
+    notes: session.notes,
+    source: session.source,
+    createdAt: session.createdAt.toISOString(),
+  };
+}
+
+export function formatSessionList(sessions: SessionRecord[]) {
+  return sessions.map(formatSession);
+}

--- a/src/views/template.ts
+++ b/src/views/template.ts
@@ -1,0 +1,56 @@
+type GridType = 'REPERTOIRE' | 'TECHNIQUE';
+type TierRequired = 'FREE' | 'PRO';
+
+/**
+ * Public fields for LibraryTemplate, excluding gridData. Used by list view.
+ * LibraryTemplateRecord is intentionally loose on gridData (`unknown`) because
+ * Prisma returns it as Prisma.JsonValue and the view doesn't touch it except
+ * in the detail variant.
+ */
+interface LibraryTemplateRecord {
+  id: string;
+  title: string;
+  author: string;
+  collection: string;
+  description: string | null;
+  instrumentTags: string[];
+  gridType: GridType;
+  tierRequired: TierRequired;
+  gridData: unknown;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export function formatTemplate(template: LibraryTemplateRecord) {
+  return {
+    id: template.id,
+    title: template.title,
+    author: template.author,
+    collection: template.collection,
+    description: template.description,
+    instrumentTags: template.instrumentTags,
+    gridType: template.gridType,
+    tierRequired: template.tierRequired,
+    active: template.active,
+    createdAt: template.createdAt.toISOString(),
+    updatedAt: template.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Detail formatter — same as formatTemplate but includes gridData. Used by
+ * `GET /api/templates/{id}` so clients can preview the blueprint before
+ * cloning.
+ */
+export function formatTemplateDetail(template: LibraryTemplateRecord) {
+  return {
+    ...formatTemplate(template),
+    gridData: template.gridData,
+  };
+}
+
+export function formatTemplateList(templates: LibraryTemplateRecord[]) {
+  return templates.map(formatTemplate);
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -23,11 +23,25 @@ export function getTestPrisma(): PrismaClient {
 
 /**
  * Deletes all data from all tables using TRUNCATE CASCADE for reliability.
+ *
+ * NOTE: All soft-delete-able and user-owned tables must be listed here.
+ * When adding a new model, add its table name to this list — otherwise tests
+ * that run later in the same file will see leftover data from earlier tests.
  */
 export async function cleanDatabase(): Promise<void> {
   const prisma = getTestPrisma();
   await prisma.$executeRawUnsafe(
-    `TRUNCATE TABLE practice_cell_completions, practice_cells, practice_rows, pieces, practice_grids, users CASCADE`,
+    `TRUNCATE TABLE
+       practice_cell_completions,
+       practice_cells,
+       practice_rows,
+       pieces,
+       practice_sessions,
+       practice_goals,
+       practice_grids,
+       library_templates,
+       users
+     CASCADE`,
   );
 }
 

--- a/tests/integration/api/goals.test.ts
+++ b/tests/integration/api/goals.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getTestPrisma } from '../../helpers/db';
+import {
+  createSeedUser as createSeedUserWith,
+  createOtherUser as createOtherUserWith,
+} from '../../helpers/fixtures';
+import {
+  createGoal,
+  listGoals,
+  getGoal,
+  updateGoal,
+  deleteGoal,
+} from '@/controllers/goal';
+
+const prisma = getTestPrisma();
+const createSeedUser = () => createSeedUserWith(prisma);
+const createOtherUser = () => createOtherUserWith(prisma);
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/goals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePutRequest(goalId: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/goals/${goalId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeListRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/goals');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+// ─── Auth failure ────────────────────────────────────────────────────────────
+
+describe('Goal API — Auth failure', () => {
+  it('returns 401 on create without seed user', async () => {
+    const res = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on list without seed user', async () => {
+    const res = await listGoals(makeListRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on get without seed user', async () => {
+    const res = await getGoal('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on update without seed user', async () => {
+    const res = await updateGoal(
+      '00000000-0000-0000-0000-000000000000',
+      makePutRequest('00000000-0000-0000-0000-000000000000', { targetValue: 60 }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on delete without seed user', async () => {
+    const res = await deleteGoal('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+describe('Goal API — Create', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('POST with valid input returns 201', async () => {
+    const res = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.goalType).toBe('DAILY_MINUTES');
+    expect(body.targetValue).toBe(30);
+    expect(body.active).toBe(true);
+  });
+
+  it('POST with invalid goalType returns 400', async () => {
+    const res = await createGoal(makePostRequest({ goalType: 'HOURLY', targetValue: 30 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with targetValue 0 returns 400', async () => {
+    const res = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 0 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with targetValue > 10000 returns 400', async () => {
+    const res = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 10001 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with empty body returns 400', async () => {
+    const res = await createGoal(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST duplicate active goalType returns 409', async () => {
+    const first = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    expect(first.status).toBe(201);
+
+    const second = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 45 }),
+    );
+    expect(second.status).toBe(409);
+    const body = await second.json();
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('POST allows different active goalTypes', async () => {
+    await createGoal(makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }));
+    const second = await createGoal(
+      makePostRequest({ goalType: 'WEEKLY_MINUTES', targetValue: 180 }),
+    );
+    expect(second.status).toBe(201);
+  });
+
+  it('POST allows same goalType after deactivation', async () => {
+    const first = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const firstBody = await first.json();
+    await updateGoal(firstBody.id, makePutRequest(firstBody.id, { active: false }));
+
+    const second = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 45 }),
+    );
+    expect(second.status).toBe(201);
+  });
+});
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+describe('Goal API — List', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('GET returns empty array when none exist', async () => {
+    const res = await listGoals(makeListRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('GET returns active goals only by default', async () => {
+    const first = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const firstBody = await first.json();
+    await updateGoal(firstBody.id, makePutRequest(firstBody.id, { active: false }));
+
+    await createGoal(makePostRequest({ goalType: 'WEEKLY_MINUTES', targetValue: 180 }));
+
+    const res = await listGoals(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].goalType).toBe('WEEKLY_MINUTES');
+  });
+
+  it('GET ?all=true returns active and inactive goals', async () => {
+    const first = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const firstBody = await first.json();
+    await updateGoal(firstBody.id, makePutRequest(firstBody.id, { active: false }));
+
+    await createGoal(makePostRequest({ goalType: 'WEEKLY_MINUTES', targetValue: 180 }));
+
+    const res = await listGoals(makeListRequest({ all: 'true' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it('GET scopes to current user', async () => {
+    await createGoal(makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }));
+
+    const otherUser = await createOtherUser();
+    await prisma.practiceGoal.create({
+      data: { userId: otherUser.id, goalType: 'WEEKLY_MINUTES', targetValue: 99 },
+    });
+
+    const res = await listGoals(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].goalType).toBe('DAILY_MINUTES');
+  });
+});
+
+// ─── Get by ID ──────────────────────────────────────────────────────────────
+
+describe('Goal API — Get by ID', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('GET /{id} returns the goal', async () => {
+    const create = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const created = await create.json();
+
+    const res = await getGoal(created.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(created.id);
+  });
+
+  it('GET /{id} returns 404 for non-existent', async () => {
+    const res = await getGoal('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} returns 404 for other-user goal', async () => {
+    const otherUser = await createOtherUser();
+    const otherGoal = await prisma.practiceGoal.create({
+      data: { userId: otherUser.id, goalType: 'DAILY_MINUTES', targetValue: 30 },
+    });
+    const res = await getGoal(otherGoal.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} with malformed UUID returns 400', async () => {
+    const res = await getGoal('bad-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Update ─────────────────────────────────────────────────────────────────
+
+describe('Goal API — Update', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  async function createdId(): Promise<string> {
+    const res = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const body = await res.json();
+    return body.id;
+  }
+
+  it('PUT updates targetValue', async () => {
+    const id = await createdId();
+    const res = await updateGoal(id, makePutRequest(id, { targetValue: 60 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.targetValue).toBe(60);
+  });
+
+  it('PUT updates active', async () => {
+    const id = await createdId();
+    const res = await updateGoal(id, makePutRequest(id, { active: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.active).toBe(false);
+  });
+
+  it('PUT rejects goalType in body (400)', async () => {
+    const id = await createdId();
+    const res = await updateGoal(
+      id,
+      makePutRequest(id, { goalType: 'WEEKLY_MINUTES' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message.toLowerCase()).toContain('goaltype');
+  });
+
+  it('PUT rejects invalid targetValue', async () => {
+    const id = await createdId();
+    const res = await updateGoal(id, makePutRequest(id, { targetValue: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT returns 404 for non-existent', async () => {
+    const res = await updateGoal(
+      '00000000-0000-0000-0000-999999999999',
+      makePutRequest('00000000-0000-0000-0000-999999999999', { targetValue: 60 }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT enforces ownership (404 for other-user)', async () => {
+    const otherUser = await createOtherUser();
+    const otherGoal = await prisma.practiceGoal.create({
+      data: { userId: otherUser.id, goalType: 'DAILY_MINUTES', targetValue: 30 },
+    });
+    const res = await updateGoal(
+      otherGoal.id,
+      makePutRequest(otherGoal.id, { targetValue: 60 }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT with malformed UUID returns 400', async () => {
+    const res = await updateGoal('bad-uuid', makePutRequest('bad-uuid', { targetValue: 60 }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Delete ─────────────────────────────────────────────────────────────────
+
+describe('Goal API — Delete', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('DELETE soft-deletes and returns 204', async () => {
+    const create = await createGoal(
+      makePostRequest({ goalType: 'DAILY_MINUTES', targetValue: 30 }),
+    );
+    const created = await create.json();
+
+    const res = await deleteGoal(created.id);
+    expect(res.status).toBe(204);
+
+    const raw = await prisma.practiceGoal.findUnique({ where: { id: created.id } });
+    expect(raw?.deletedAt).not.toBeNull();
+  });
+
+  it('DELETE returns 404 for non-existent', async () => {
+    const res = await deleteGoal('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE returns 404 for other-user goal', async () => {
+    const otherUser = await createOtherUser();
+    const otherGoal = await prisma.practiceGoal.create({
+      data: { userId: otherUser.id, goalType: 'DAILY_MINUTES', targetValue: 30 },
+    });
+    const res = await deleteGoal(otherGoal.id);
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/integration/api/goals.test.ts
+++ b/tests/integration/api/goals.test.ts
@@ -298,6 +298,33 @@ describe('Goal API — Update', () => {
     expect(res.status).toBe(400);
   });
 
+  it('PUT rejects non-number targetValue (type check)', async () => {
+    const id = await createdId();
+    const res = await updateGoal(id, makePutRequest(id, { targetValue: '60' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message.toLowerCase()).toContain('targetvalue');
+  });
+
+  it('PUT rejects non-boolean active (type check)', async () => {
+    const id = await createdId();
+    const res = await updateGoal(id, makePutRequest(id, { active: 'yes' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message.toLowerCase()).toContain('active');
+  });
+
+  it('PUT rejects empty body', async () => {
+    const id = await createdId();
+    const req = new NextRequest(`http://localhost:3000/api/goals/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not valid json',
+    });
+    const res = await updateGoal(id, req);
+    expect(res.status).toBe(400);
+  });
+
   it('PUT returns 404 for non-existent', async () => {
     const res = await updateGoal(
       '00000000-0000-0000-0000-999999999999',

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -11,6 +11,7 @@ import {
   listGrids,
   getGrid,
   deleteGrid,
+  updateGrid,
 } from '@/controllers/grid';
 import { completeCell } from '@/controllers/cell';
 
@@ -846,5 +847,270 @@ describe('Grid API — Detail Freshness Fields', () => {
     expect(afterCell.freshnessState).toBe('fresh');
     expect(afterCell.lastCompletionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(typeof afterCell.isShielded).toBe('boolean');
+  });
+});
+
+// ─── M2.1: Update Grid + Archived Filter + New Fields ────────────────────────
+
+function makeUpdateRequest(gridId: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/grids/${gridId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Grid API — New Response Fields (gridType, archived, sourceTemplateId)', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('grid create response includes gridType, archived, sourceTemplateId', async () => {
+    const res = await createGrid(makeRequest({ name: 'New Grid' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.gridType).toBe('REPERTOIRE');
+    expect(body.archived).toBe(false);
+    expect(body.sourceTemplateId).toBeNull();
+  });
+
+  it('grid detail response includes gridType, archived, sourceTemplateId', async () => {
+    const create = await createGrid(makeRequest({ name: 'Detail Grid' }));
+    const created = await create.json();
+
+    const res = await getGrid(created.id);
+    const body = await res.json();
+    expect(body.gridType).toBe('REPERTOIRE');
+    expect(body.archived).toBe(false);
+    expect(body.sourceTemplateId).toBeNull();
+  });
+
+  it('grid list response includes gridType, archived, sourceTemplateId', async () => {
+    await createGrid(makeRequest({ name: 'List Grid' }));
+    const res = await listGrids(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].gridType).toBe('REPERTOIRE');
+    expect(body[0].archived).toBe(false);
+    expect(body[0].sourceTemplateId).toBeNull();
+  });
+});
+
+describe('Grid API — Update (PUT)', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  async function createdGridId(): Promise<string> {
+    const res = await createGrid(makeRequest({ name: 'Original' }));
+    const body = await res.json();
+    return body.id;
+  }
+
+  it('PUT updates name', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { name: 'Renamed' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe('Renamed');
+  });
+
+  it('PUT updates notes', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { notes: 'New notes' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notes).toBe('New notes');
+  });
+
+  it('PUT updates notes to null', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { notes: null }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notes).toBeNull();
+  });
+
+  it('PUT updates gridType to TECHNIQUE', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { gridType: 'TECHNIQUE' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.gridType).toBe('TECHNIQUE');
+  });
+
+  it('PUT rejects invalid gridType', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { gridType: 'INVALID' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('PUT updates archived to true', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { archived: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.archived).toBe(true);
+  });
+
+  it('PUT updates fadeEnabled', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { fadeEnabled: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fadeEnabled).toBe(false);
+  });
+
+  it('PUT updates multiple fields atomically', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(
+      id,
+      makeUpdateRequest(id, { name: 'Multi', notes: 'x', archived: true, gridType: 'TECHNIQUE' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe('Multi');
+    expect(body.notes).toBe('x');
+    expect(body.archived).toBe(true);
+    expect(body.gridType).toBe('TECHNIQUE');
+  });
+
+  it('PUT rejects empty name', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { name: '' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('PUT rejects whitespace-only name', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { name: '   ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT rejects sourceTemplateId in body (immutable)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(
+      id,
+      makeUpdateRequest(id, { sourceTemplateId: '00000000-0000-0000-0000-000000000001' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.message.toLowerCase()).toContain('sourcetemplateid');
+  });
+
+  it('PUT returns 404 for non-existent grid', async () => {
+    const res = await updateGrid(
+      '00000000-0000-0000-0000-999999999999',
+      makeUpdateRequest('00000000-0000-0000-0000-999999999999', { name: 'x' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT returns 400 for malformed UUID', async () => {
+    const res = await updateGrid('bad-uuid', makeUpdateRequest('bad-uuid', { name: 'x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT enforces ownership (404 for other-user grids)', async () => {
+    const otherUser = await createOtherUser();
+    const otherGrid = await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Theirs' },
+    });
+    const res = await updateGrid(otherGrid.id, makeUpdateRequest(otherGrid.id, { name: 'x' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT returns 401 when unauthenticated', async () => {
+    // Delete seed user to trigger auth failure
+    await prisma.user.deleteMany({ where: { email: 'dev-placeholder@tessitura.local' } });
+    const res = await updateGrid(
+      '00000000-0000-0000-0000-000000000000',
+      makeUpdateRequest('00000000-0000-0000-0000-000000000000', { name: 'x' }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Grid API — Archived Filter', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  async function createWithArchived(name: string, archived: boolean): Promise<string> {
+    const res = await createGrid(makeRequest({ name }));
+    const body = await res.json();
+    if (archived) {
+      await updateGrid(body.id, makeUpdateRequest(body.id, { archived: true }));
+    }
+    return body.id;
+  }
+
+  it('GET /api/grids excludes archived by default', async () => {
+    await createWithArchived('Active 1', false);
+    await createWithArchived('Archived 1', true);
+
+    const res = await listGrids(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('Active 1');
+  });
+
+  it('GET /api/grids?archived=false returns active only (explicit)', async () => {
+    await createWithArchived('Active 1', false);
+    await createWithArchived('Archived 1', true);
+
+    const res = await listGrids(makeListRequest({ archived: 'false' }));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('Active 1');
+  });
+
+  it('GET /api/grids?archived=true returns archived only', async () => {
+    await createWithArchived('Active 1', false);
+    await createWithArchived('Archived 1', true);
+    await createWithArchived('Archived 2', true);
+
+    const res = await listGrids(makeListRequest({ archived: 'true' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body.every((g: { archived: boolean }) => g.archived === true)).toBe(true);
+  });
+
+  it('GET /api/grids?archived=all returns both', async () => {
+    await createWithArchived('Active 1', false);
+    await createWithArchived('Archived 1', true);
+
+    const res = await listGrids(makeListRequest({ archived: 'all' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it('GET /api/grids?detail=true&archived=true composes both filters', async () => {
+    await createWithArchived('Active 1', false);
+    await createWithArchived('Archived 1', true);
+
+    const res = await listGrids(makeListRequest({ detail: 'true', archived: 'true' }));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('Archived 1');
+    expect(body[0].archived).toBe(true);
+    // Detail-view fields are present
+    expect(body[0]).toHaveProperty('completionPercentage');
+    expect(body[0]).toHaveProperty('freshnessSummary');
+  });
+
+  it('GET /api/grids/{id} still returns archived grids by direct access', async () => {
+    const id = await createWithArchived('Archived Direct', true);
+
+    const res = await getGrid(id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.archived).toBe(true);
+    expect(body.name).toBe('Archived Direct');
   });
 });

--- a/tests/integration/api/grids.test.ts
+++ b/tests/integration/api/grids.test.ts
@@ -963,6 +963,69 @@ describe('Grid API — Update (PUT)', () => {
     expect(body.fadeEnabled).toBe(false);
   });
 
+  it('PUT rejects non-boolean archived (type check)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { archived: 'yes' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message.toLowerCase()).toContain('archived');
+  });
+
+  it('PUT rejects non-boolean fadeEnabled (type check)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { fadeEnabled: 'yes' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message.toLowerCase()).toContain('fadeenabled');
+  });
+
+  it('PUT rejects non-string name (type check)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { name: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT rejects non-string notes (type check)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { notes: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT rejects non-string gridType (type check)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, { gridType: 42 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT accepts notes=null to clear', async () => {
+    const id = await createdGridId();
+    // First set notes, then clear
+    await updateGrid(id, makeUpdateRequest(id, { notes: 'will clear' }));
+    const res = await updateGrid(id, makeUpdateRequest(id, { notes: null }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notes).toBeNull();
+  });
+
+  it('PUT rejects malformed JSON body', async () => {
+    const id = await createdGridId();
+    const req = new NextRequest(`http://localhost:3000/api/grids/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not valid json',
+    });
+    const res = await updateGrid(id, req);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT with no updatable fields returns current grid (no-op)', async () => {
+    const id = await createdGridId();
+    const res = await updateGrid(id, makeUpdateRequest(id, {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(id);
+  });
+
   it('PUT updates multiple fields atomically', async () => {
     const id = await createdGridId();
     const res = await updateGrid(

--- a/tests/integration/api/sessions.test.ts
+++ b/tests/integration/api/sessions.test.ts
@@ -166,6 +166,27 @@ describe('Session API — Create', () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it('POST with non-string practiceGridId returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({
+        sessionDate: '2026-04-01',
+        durationMinutes: 30,
+        practiceGridId: 42,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with empty JSON body returns 400', async () => {
+    const req = new NextRequest('http://localhost:3000/api/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not valid json',
+    });
+    const res = await createSession(req);
+    expect(res.status).toBe(400);
+  });
 });
 
 // ─── List ───────────────────────────────────────────────────────────────────
@@ -200,12 +221,32 @@ describe('Session API — List', () => {
   });
 
   it('GET sorts same-day sessions by createdAt desc', async () => {
-    await createSession(
-      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 10, notes: 'first' }),
-    );
-    await createSession(
-      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 20, notes: 'second' }),
-    );
+    // Insert directly via raw prisma with explicit, distinct createdAt values.
+    // Going through the controller's POST path would use the Prisma @default(now())
+    // clock, which at microsecond resolution can produce identical values for
+    // back-to-back inserts on a fast runner — flaky.
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    await prisma.practiceSession.create({
+      data: {
+        userId: user.id,
+        sessionDate: new Date('2026-04-01T00:00:00.000Z'),
+        durationMinutes: 10,
+        notes: 'first',
+        createdAt: new Date('2026-04-01T10:00:00.000Z'),
+      },
+    });
+    await prisma.practiceSession.create({
+      data: {
+        userId: user.id,
+        sessionDate: new Date('2026-04-01T00:00:00.000Z'),
+        durationMinutes: 20,
+        notes: 'second',
+        createdAt: new Date('2026-04-01T10:00:01.000Z'),
+      },
+    });
+
     const res = await listSessions(makeListRequest());
     const body = await res.json();
     expect(body[0].notes).toBe('second');

--- a/tests/integration/api/sessions.test.ts
+++ b/tests/integration/api/sessions.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getTestPrisma } from '../../helpers/db';
+import {
+  createSeedUser as createSeedUserWith,
+  createOtherUser as createOtherUserWith,
+} from '../../helpers/fixtures';
+import {
+  createSession,
+  listSessions,
+  getSession,
+  deleteSession,
+} from '@/controllers/session';
+
+const prisma = getTestPrisma();
+const createSeedUser = () => createSeedUserWith(prisma);
+const createOtherUser = () => createOtherUserWith(prisma);
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeListRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/sessions');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+// ─── Auth failure ────────────────────────────────────────────────────────────
+
+describe('Session API — Auth failure', () => {
+  it('returns 401 on create without seed user', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30 }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('AUTHENTICATION_ERROR');
+  });
+
+  it('returns 401 on list without seed user', async () => {
+    const res = await listSessions(makeListRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on get without seed user', async () => {
+    const res = await getSession('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on delete without seed user', async () => {
+    const res = await deleteSession('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+describe('Session API — Create', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('POST with valid input returns 201', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30, notes: 'Scales' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.sessionDate).toBe('2026-04-01');
+    expect(body.durationMinutes).toBe(30);
+    expect(body.notes).toBe('Scales');
+    expect(body.source).toBe('MANUAL');
+    expect(body.practiceGridId).toBeNull();
+  });
+
+  it('POST with practiceGridId owned by user returns 201', async () => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grid = await prisma.practiceGrid.create({
+      data: { userId: user.id, name: 'Linked Grid' },
+    });
+    const res = await createSession(
+      makePostRequest({
+        sessionDate: '2026-04-01',
+        durationMinutes: 45,
+        practiceGridId: grid.id,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.practiceGridId).toBe(grid.id);
+  });
+
+  it('POST with practiceGridId for other user returns 400', async () => {
+    const otherUser = await createOtherUser();
+    const otherGrid = await prisma.practiceGrid.create({
+      data: { userId: otherUser.id, name: 'Theirs' },
+    });
+    const res = await createSession(
+      makePostRequest({
+        sessionDate: '2026-04-01',
+        durationMinutes: 30,
+        practiceGridId: otherGrid.id,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('POST with invalid date returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '04/01/2026', durationMinutes: 30 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with duration 0 returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 0 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with duration 1441 returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 1441 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with empty body returns 400', async () => {
+    const res = await createSession(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with malformed practiceGridId returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({
+        sessionDate: '2026-04-01',
+        durationMinutes: 30,
+        practiceGridId: 'not-a-uuid',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with non-number durationMinutes returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: '30' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST with non-string notes returns 400', async () => {
+    const res = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30, notes: 123 }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+describe('Session API — List', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  async function createFor(dates: string[]): Promise<void> {
+    for (const d of dates) {
+      await createSession(makePostRequest({ sessionDate: d, durationMinutes: 30 }));
+    }
+  }
+
+  it('GET returns empty array when no sessions', async () => {
+    const res = await listSessions(makeListRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('GET returns sessions sorted by sessionDate desc', async () => {
+    await createFor(['2026-04-01', '2026-04-03', '2026-04-02']);
+
+    const res = await listSessions(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(3);
+    expect(body[0].sessionDate).toBe('2026-04-03');
+    expect(body[1].sessionDate).toBe('2026-04-02');
+    expect(body[2].sessionDate).toBe('2026-04-01');
+  });
+
+  it('GET sorts same-day sessions by createdAt desc', async () => {
+    await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 10, notes: 'first' }),
+    );
+    await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 20, notes: 'second' }),
+    );
+    const res = await listSessions(makeListRequest());
+    const body = await res.json();
+    expect(body[0].notes).toBe('second');
+    expect(body[1].notes).toBe('first');
+  });
+
+  it('GET ?from filter is inclusive', async () => {
+    await createFor(['2026-04-01', '2026-04-02', '2026-04-03']);
+    const res = await listSessions(makeListRequest({ from: '2026-04-02' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body.map((s: { sessionDate: string }) => s.sessionDate).sort()).toEqual([
+      '2026-04-02',
+      '2026-04-03',
+    ]);
+  });
+
+  it('GET ?to filter is inclusive', async () => {
+    await createFor(['2026-04-01', '2026-04-02', '2026-04-03']);
+    const res = await listSessions(makeListRequest({ to: '2026-04-02' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body.map((s: { sessionDate: string }) => s.sessionDate).sort()).toEqual([
+      '2026-04-01',
+      '2026-04-02',
+    ]);
+  });
+
+  it('GET ?from=&to= combines both inclusively', async () => {
+    await createFor(['2026-04-01', '2026-04-02', '2026-04-03', '2026-04-04']);
+    const res = await listSessions(makeListRequest({ from: '2026-04-02', to: '2026-04-03' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it('GET ?from with invalid format returns 400', async () => {
+    const res = await listSessions(makeListRequest({ from: '04/01/2026' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('GET scopes to current user (does not leak others)', async () => {
+    await createFor(['2026-04-01']);
+
+    const otherUser = await createOtherUser();
+    await prisma.practiceSession.create({
+      data: {
+        userId: otherUser.id,
+        sessionDate: new Date('2026-04-01T00:00:00Z'),
+        durationMinutes: 99,
+      },
+    });
+
+    const res = await listSessions(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+  });
+
+  it('GET excludes soft-deleted sessions', async () => {
+    const create = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30 }),
+    );
+    const created = await create.json();
+    await deleteSession(created.id);
+
+    const res = await listSessions(makeListRequest());
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+});
+
+// ─── Get by ID ──────────────────────────────────────────────────────────────
+
+describe('Session API — Get by ID', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('GET /{id} returns the session', async () => {
+    const create = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30 }),
+    );
+    const created = await create.json();
+
+    const res = await getSession(created.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(created.id);
+  });
+
+  it('GET /{id} for non-existent session returns 404', async () => {
+    const res = await getSession('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} for other-user session returns 404', async () => {
+    const otherUser = await createOtherUser();
+    const otherSession = await prisma.practiceSession.create({
+      data: {
+        userId: otherUser.id,
+        sessionDate: new Date('2026-04-01T00:00:00Z'),
+        durationMinutes: 30,
+      },
+    });
+    const res = await getSession(otherSession.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} with malformed UUID returns 400', async () => {
+    const res = await getSession('bad-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Delete ─────────────────────────────────────────────────────────────────
+
+describe('Session API — Delete', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('DELETE soft-deletes and returns 204', async () => {
+    const create = await createSession(
+      makePostRequest({ sessionDate: '2026-04-01', durationMinutes: 30 }),
+    );
+    const created = await create.json();
+
+    const res = await deleteSession(created.id);
+    expect(res.status).toBe(204);
+
+    // Raw client sees the soft-deleted row
+    const raw = await prisma.practiceSession.findUnique({ where: { id: created.id } });
+    expect(raw?.deletedAt).not.toBeNull();
+  });
+
+  it('DELETE for non-existent session returns 404', async () => {
+    const res = await deleteSession('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE for other-user session returns 404', async () => {
+    const otherUser = await createOtherUser();
+    const otherSession = await prisma.practiceSession.create({
+      data: {
+        userId: otherUser.id,
+        sessionDate: new Date('2026-04-01T00:00:00Z'),
+        durationMinutes: 30,
+      },
+    });
+    const res = await deleteSession(otherSession.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE with malformed UUID returns 400', async () => {
+    const res = await deleteSession('bad-uuid');
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/api/templates.test.ts
+++ b/tests/integration/api/templates.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getTestPrisma } from '../../helpers/db';
+import { createSeedUser as createSeedUserWith } from '../../helpers/fixtures';
+import {
+  listTemplates,
+  getTemplate,
+  cloneTemplate,
+} from '@/controllers/template';
+
+const prisma = getTestPrisma();
+const createSeedUser = () => createSeedUserWith(prisma);
+
+function makeListRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/templates');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+async function seedTemplate(overrides: {
+  id?: string;
+  title?: string;
+  author?: string;
+  instrumentTags?: string[];
+  gridType?: 'REPERTOIRE' | 'TECHNIQUE';
+  active?: boolean;
+  gridData?: object;
+} = {}) {
+  return prisma.libraryTemplate.create({
+    data: {
+      id: overrides.id,
+      title: overrides.title ?? 'Clarke Technical Studies',
+      author: overrides.author ?? 'Herbert L. Clarke',
+      collection: 'Technical Studies for the Cornet',
+      instrumentTags: overrides.instrumentTags ?? ['trumpet', 'cornet', 'brass'],
+      gridType: overrides.gridType ?? 'REPERTOIRE',
+      active: overrides.active ?? true,
+      gridData: (overrides.gridData ?? {
+        rows: [
+          { passageLabel: 'Study #1', startMeasure: 1, endMeasure: 16, targetTempo: 120, steps: 5 },
+          { passageLabel: 'Study #2', startMeasure: 1, endMeasure: 24, targetTempo: 108, steps: 4 },
+        ],
+      }) as object,
+    },
+  });
+}
+
+// ─── Auth failure ────────────────────────────────────────────────────────────
+
+describe('Template API — Auth failure', () => {
+  it('returns 401 on list without seed user', async () => {
+    const res = await listTemplates(makeListRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on get without seed user', async () => {
+    const res = await getTemplate('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on clone without seed user', async () => {
+    const res = await cloneTemplate('00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+describe('Template API — List', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('GET returns empty array when no templates', async () => {
+    const res = await listTemplates(makeListRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('GET returns active templates only', async () => {
+    await seedTemplate({ title: 'Active' });
+    await seedTemplate({ title: 'Inactive', active: false });
+
+    const res = await listTemplates(makeListRequest());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe('Active');
+  });
+
+  it('GET does not include gridData in list response (summary only)', async () => {
+    await seedTemplate({ title: 'With GridData' });
+    const res = await listTemplates(makeListRequest());
+    const body = await res.json();
+    expect(body[0]).not.toHaveProperty('gridData');
+  });
+
+  it('GET includes instrumentTags and gridType', async () => {
+    await seedTemplate({ title: 'Tagged', instrumentTags: ['trumpet'] });
+    const res = await listTemplates(makeListRequest());
+    const body = await res.json();
+    expect(body[0].instrumentTags).toEqual(['trumpet']);
+    expect(body[0].gridType).toBe('REPERTOIRE');
+  });
+
+  it('GET ?instrument=trumpet filters (case-insensitive substring)', async () => {
+    await seedTemplate({ title: 'Trumpet Studies', instrumentTags: ['trumpet'] });
+    await seedTemplate({ title: 'Violin Studies', instrumentTags: ['violin'] });
+    await seedTemplate({ title: 'Brass Ensemble', instrumentTags: ['trumpet', 'horn'] });
+
+    const res = await listTemplates(makeListRequest({ instrument: 'TRUMPET' }));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    const titles = body.map((t: { title: string }) => t.title).sort();
+    expect(titles).toEqual(['Brass Ensemble', 'Trumpet Studies']);
+  });
+});
+
+// ─── Get detail ─────────────────────────────────────────────────────────────
+
+describe('Template API — Get detail', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('GET /{id} returns template with gridData', async () => {
+    const template = await seedTemplate();
+    const res = await getTemplate(template.id);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(template.id);
+    expect(body.gridData).toBeDefined();
+    expect(body.gridData.rows).toHaveLength(2);
+  });
+
+  it('GET /{id} returns 404 for non-existent template', async () => {
+    const res = await getTemplate('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} returns 404 for inactive template', async () => {
+    const template = await seedTemplate({ active: false });
+    const res = await getTemplate(template.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /{id} with malformed UUID returns 400', async () => {
+    const res = await getTemplate('bad-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Clone ──────────────────────────────────────────────────────────────────
+
+describe('Template API — Clone', () => {
+  beforeEach(async () => {
+    await createSeedUser();
+  });
+
+  it('POST /{id}/clone creates a grid with rows and cells', async () => {
+    const template = await seedTemplate();
+    const res = await cloneTemplate(template.id);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+
+    // Grid fields
+    expect(body.name).toBe('Clarke Technical Studies');
+    expect(body.gridType).toBe('REPERTOIRE');
+    expect(body.sourceTemplateId).toBe(template.id);
+    expect(body.archived).toBe(false);
+    expect(body.fadeEnabled).toBe(true);
+
+    // Grid detail fields
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows[0].cells).toHaveLength(5);
+    expect(body.rows[1].cells).toHaveLength(4);
+
+    // Passage labels carried through
+    expect(body.rows[0].passageLabel).toBe('Study #1');
+    expect(body.rows[1].passageLabel).toBe('Study #2');
+
+    // Cells use the standard percentage formula — last cell is always 100%
+    expect(body.rows[0].cells[4].targetTempoBpm).toBe(120);
+    expect(body.rows[1].cells[3].targetTempoBpm).toBe(108);
+  });
+
+  it('POST /{id}/clone uses template.gridType (TECHNIQUE)', async () => {
+    const template = await seedTemplate({ gridType: 'TECHNIQUE' });
+    const res = await cloneTemplate(template.id);
+    const body = await res.json();
+    expect(body.gridType).toBe('TECHNIQUE');
+  });
+
+  it('POST /{id}/clone is transactional — no partial grid on validation failure', async () => {
+    // Create template with invalid gridData directly via prisma (bypass validation)
+    const template = await seedTemplate({
+      title: 'Bad Template',
+      gridData: {
+        rows: [
+          { passageLabel: 'OK', startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 3 },
+          // Second row fails validation (steps > 50)
+          { passageLabel: 'Bad', startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 99 },
+        ],
+      },
+    });
+
+    const res = await cloneTemplate(template.id);
+    expect(res.status).toBe(400);
+
+    // Assert no partial grid was created — count all practice_grids for seed user
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: 'dev-placeholder@tessitura.local' },
+    });
+    const grids = await prisma.practiceGrid.findMany({ where: { userId: user.id } });
+    expect(grids).toHaveLength(0);
+  });
+
+  it('POST /{id}/clone returns 404 for non-existent template', async () => {
+    const res = await cloneTemplate('00000000-0000-0000-0000-999999999999');
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /{id}/clone returns 404 for inactive template', async () => {
+    const template = await seedTemplate({ active: false });
+    const res = await cloneTemplate(template.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /{id}/clone with malformed UUID returns 400', async () => {
+    const res = await cloneTemplate('bad-uuid');
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /{id}/clone creates distinct grids on repeated clones', async () => {
+    const template = await seedTemplate();
+    const first = await cloneTemplate(template.id);
+    const firstBody = await first.json();
+    const second = await cloneTemplate(template.id);
+    const secondBody = await second.json();
+    expect(firstBody.id).not.toBe(secondBody.id);
+    expect(firstBody.sourceTemplateId).toBe(template.id);
+    expect(secondBody.sourceTemplateId).toBe(template.id);
+  });
+});

--- a/tests/unit/controllers/error-handling.test.ts
+++ b/tests/unit/controllers/error-handling.test.ts
@@ -16,9 +16,33 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@/models/grid', () => ({
   createGrid: vi.fn(() => { throw new Error('db exploded'); }),
   listGrids: vi.fn(() => { throw new Error('db exploded'); }),
+  listGridsWithDetail: vi.fn(() => { throw new Error('db exploded'); }),
   getGridById: vi.fn(() => { throw new Error('db exploded'); }),
   deleteGrid: vi.fn(() => { throw new Error('db exploded'); }),
+  updateGrid: vi.fn(() => { throw new Error('db exploded'); }),
   updateGridFade: vi.fn(() => { throw new Error('db exploded'); }),
+  findOwnedGrid: vi.fn(() => { throw new Error('db exploded'); }),
+}));
+
+vi.mock('@/models/session', () => ({
+  createSession: vi.fn(() => { throw new Error('db exploded'); }),
+  listSessions: vi.fn(() => { throw new Error('db exploded'); }),
+  getSessionById: vi.fn(() => { throw new Error('db exploded'); }),
+  deleteSession: vi.fn(() => { throw new Error('db exploded'); }),
+}));
+
+vi.mock('@/models/goal', () => ({
+  createGoal: vi.fn(() => { throw new Error('db exploded'); }),
+  listGoals: vi.fn(() => { throw new Error('db exploded'); }),
+  getGoalById: vi.fn(() => { throw new Error('db exploded'); }),
+  updateGoal: vi.fn(() => { throw new Error('db exploded'); }),
+  deleteGoal: vi.fn(() => { throw new Error('db exploded'); }),
+}));
+
+vi.mock('@/models/template', () => ({
+  listTemplates: vi.fn(() => { throw new Error('db exploded'); }),
+  getTemplateById: vi.fn(() => { throw new Error('db exploded'); }),
+  cloneTemplate: vi.fn(() => { throw new Error('db exploded'); }),
 }));
 
 vi.mock('@/models/piece', () => ({
@@ -97,6 +121,129 @@ describe('Grid controller — unexpected errors → 500', () => {
     const { updateFade } = await import('@/controllers/grid');
     const req = jsonRequest('PUT', { fadeEnabled: true });
     const res = await updateFade(VALID_UUID, req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('updateGrid returns 500 on unexpected error', async () => {
+    const { updateGrid } = await import('@/controllers/grid');
+    const req = jsonRequest('PUT', { name: 'Renamed' });
+    const res = await updateGrid(VALID_UUID, req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── Session controller ─────────────────────────────────────────────────────
+
+describe('Session controller — unexpected errors → 500', () => {
+  it('createSession returns 500 on unexpected error', async () => {
+    const { createSession } = await import('@/controllers/session');
+    const req = jsonRequest('POST', { sessionDate: '2026-04-01', durationMinutes: 30 });
+    const res = await createSession(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('listSessions returns 500 on unexpected error', async () => {
+    const { listSessions } = await import('@/controllers/session');
+    const req = new NextRequest('http://localhost:3000/api/sessions');
+    const res = await listSessions(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('getSession returns 500 on unexpected error', async () => {
+    const { getSession } = await import('@/controllers/session');
+    const res = await getSession(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('deleteSession returns 500 on unexpected error', async () => {
+    const { deleteSession } = await import('@/controllers/session');
+    const res = await deleteSession(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── Goal controller ────────────────────────────────────────────────────────
+
+describe('Goal controller — unexpected errors → 500', () => {
+  it('createGoal returns 500 on unexpected error', async () => {
+    const { createGoal } = await import('@/controllers/goal');
+    const req = jsonRequest('POST', { goalType: 'DAILY_MINUTES', targetValue: 30 });
+    const res = await createGoal(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('listGoals returns 500 on unexpected error', async () => {
+    const { listGoals } = await import('@/controllers/goal');
+    const req = new NextRequest('http://localhost:3000/api/goals');
+    const res = await listGoals(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('getGoal returns 500 on unexpected error', async () => {
+    const { getGoal } = await import('@/controllers/goal');
+    const res = await getGoal(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('updateGoal returns 500 on unexpected error', async () => {
+    const { updateGoal } = await import('@/controllers/goal');
+    const req = jsonRequest('PUT', { targetValue: 60 });
+    const res = await updateGoal(VALID_UUID, req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('deleteGoal returns 500 on unexpected error', async () => {
+    const { deleteGoal } = await import('@/controllers/goal');
+    const res = await deleteGoal(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── Template controller ────────────────────────────────────────────────────
+
+describe('Template controller — unexpected errors → 500', () => {
+  it('listTemplates returns 500 on unexpected error', async () => {
+    const { listTemplates } = await import('@/controllers/template');
+    const req = new NextRequest('http://localhost:3000/api/templates');
+    const res = await listTemplates(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('getTemplate returns 500 on unexpected error', async () => {
+    const { getTemplate } = await import('@/controllers/template');
+    const res = await getTemplate(VALID_UUID);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('cloneTemplate returns 500 on unexpected error', async () => {
+    const { cloneTemplate } = await import('@/controllers/template');
+    const res = await cloneTemplate(VALID_UUID);
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.error.code).toBe('INTERNAL_ERROR');

--- a/tests/unit/models/goal.test.ts
+++ b/tests/unit/models/goal.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateGoalInput,
+  validateGoalUpdate,
+  type GoalInput,
+  type GoalUpdateInput,
+} from '@/models/goal';
+import { ValidationError } from '@/lib/errors';
+
+function baseInput(overrides: Partial<GoalInput> = {}): GoalInput {
+  return {
+    goalType: 'DAILY_MINUTES',
+    targetValue: 30,
+    ...overrides,
+  };
+}
+
+describe('validateGoalInput — goalType', () => {
+  it('accepts DAILY_MINUTES', () => {
+    expect(validateGoalInput(baseInput({ goalType: 'DAILY_MINUTES' })).goalType).toBe(
+      'DAILY_MINUTES',
+    );
+  });
+
+  it('accepts WEEKLY_MINUTES', () => {
+    expect(validateGoalInput(baseInput({ goalType: 'WEEKLY_MINUTES' })).goalType).toBe(
+      'WEEKLY_MINUTES',
+    );
+  });
+
+  it('accepts WEEKLY_SESSIONS', () => {
+    expect(validateGoalInput(baseInput({ goalType: 'WEEKLY_SESSIONS' })).goalType).toBe(
+      'WEEKLY_SESSIONS',
+    );
+  });
+
+  it('accepts MONTHLY_GRIDS', () => {
+    expect(validateGoalInput(baseInput({ goalType: 'MONTHLY_GRIDS' })).goalType).toBe(
+      'MONTHLY_GRIDS',
+    );
+  });
+
+  it('rejects unknown goalType', () => {
+    expect(() => validateGoalInput(baseInput({ goalType: 'HOURLY' }))).toThrow(ValidationError);
+  });
+
+  it('rejects lowercase goalType', () => {
+    expect(() => validateGoalInput(baseInput({ goalType: 'daily_minutes' }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects missing goalType', () => {
+    expect(() => validateGoalInput({ targetValue: 30 } as unknown as GoalInput)).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects non-string goalType', () => {
+    expect(() =>
+      validateGoalInput(baseInput({ goalType: 123 as unknown as string })),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateGoalInput — targetValue', () => {
+  it('accepts lower bound (1)', () => {
+    expect(validateGoalInput(baseInput({ targetValue: 1 })).targetValue).toBe(1);
+  });
+
+  it('accepts upper bound (10000)', () => {
+    expect(validateGoalInput(baseInput({ targetValue: 10000 })).targetValue).toBe(10000);
+  });
+
+  it('rejects 0', () => {
+    expect(() => validateGoalInput(baseInput({ targetValue: 0 }))).toThrow(ValidationError);
+  });
+
+  it('rejects negative', () => {
+    expect(() => validateGoalInput(baseInput({ targetValue: -1 }))).toThrow(ValidationError);
+  });
+
+  it('rejects > 10000', () => {
+    expect(() => validateGoalInput(baseInput({ targetValue: 10001 }))).toThrow(ValidationError);
+  });
+
+  it('rejects non-integer', () => {
+    expect(() => validateGoalInput(baseInput({ targetValue: 30.5 }))).toThrow(ValidationError);
+  });
+
+  it('rejects non-number', () => {
+    expect(() =>
+      validateGoalInput(baseInput({ targetValue: '30' as unknown as number })),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateGoalUpdate', () => {
+  it('accepts targetValue-only update', () => {
+    const result = validateGoalUpdate({ targetValue: 60 });
+    expect(result.targetValue).toBe(60);
+    expect(result.active).toBeUndefined();
+  });
+
+  it('accepts active-only update', () => {
+    const result = validateGoalUpdate({ active: false });
+    expect(result.active).toBe(false);
+    expect(result.targetValue).toBeUndefined();
+  });
+
+  it('accepts both fields', () => {
+    const result = validateGoalUpdate({ targetValue: 45, active: true });
+    expect(result.targetValue).toBe(45);
+    expect(result.active).toBe(true);
+  });
+
+  it('rejects goalType in body (immutable after create)', () => {
+    expect(() =>
+      validateGoalUpdate({ goalType: 'WEEKLY_MINUTES' } as unknown as GoalUpdateInput),
+    ).toThrow(/goalType.*cannot be changed/i);
+  });
+
+  it('rejects invalid targetValue', () => {
+    expect(() => validateGoalUpdate({ targetValue: 0 })).toThrow(ValidationError);
+    expect(() => validateGoalUpdate({ targetValue: 10001 })).toThrow(ValidationError);
+  });
+
+  it('rejects non-boolean active', () => {
+    expect(() =>
+      validateGoalUpdate({ active: 'yes' as unknown as boolean }),
+    ).toThrow(ValidationError);
+  });
+
+  it('accepts empty update object', () => {
+    const result = validateGoalUpdate({});
+    expect(result).toEqual({});
+  });
+});

--- a/tests/unit/models/session.test.ts
+++ b/tests/unit/models/session.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { validateSessionInput, type SessionInput } from '@/models/session';
+import { ValidationError } from '@/lib/errors';
+
+function baseInput(overrides: Partial<SessionInput> = {}): SessionInput {
+  return {
+    sessionDate: '2026-04-01',
+    durationMinutes: 30,
+    ...overrides,
+  };
+}
+
+describe('validateSessionInput — sessionDate', () => {
+  it('accepts a valid YYYY-MM-DD string', () => {
+    const result = validateSessionInput(baseInput({ sessionDate: '2026-04-01' }));
+    expect(result.sessionDate).toBe('2026-04-01');
+  });
+
+  it('rejects a non-string sessionDate', () => {
+    expect(() => validateSessionInput(baseInput({ sessionDate: 42 as unknown as string }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects missing sessionDate', () => {
+    expect(() =>
+      validateSessionInput({ durationMinutes: 30 } as unknown as SessionInput),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects malformed sessionDate (wrong separators)', () => {
+    expect(() => validateSessionInput(baseInput({ sessionDate: '2026/04/01' }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects malformed sessionDate (month/day out of range)', () => {
+    expect(() => validateSessionInput(baseInput({ sessionDate: '2026-13-01' }))).toThrow(
+      ValidationError,
+    );
+    expect(() => validateSessionInput(baseInput({ sessionDate: '2026-04-32' }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects malformed sessionDate (short zero-padding)', () => {
+    expect(() => validateSessionInput(baseInput({ sessionDate: '2026-4-1' }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects a Date object (this is a calendar date — strings only)', () => {
+    expect(() =>
+      validateSessionInput(baseInput({ sessionDate: new Date('2026-04-01') as unknown as string })),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateSessionInput — durationMinutes', () => {
+  it('accepts the lower bound (1)', () => {
+    const result = validateSessionInput(baseInput({ durationMinutes: 1 }));
+    expect(result.durationMinutes).toBe(1);
+  });
+
+  it('accepts the upper bound (1440 = 24h)', () => {
+    const result = validateSessionInput(baseInput({ durationMinutes: 1440 }));
+    expect(result.durationMinutes).toBe(1440);
+  });
+
+  it('rejects 0', () => {
+    expect(() => validateSessionInput(baseInput({ durationMinutes: 0 }))).toThrow(ValidationError);
+  });
+
+  it('rejects negative', () => {
+    expect(() => validateSessionInput(baseInput({ durationMinutes: -1 }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects > 1440', () => {
+    expect(() => validateSessionInput(baseInput({ durationMinutes: 1441 }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects non-integer', () => {
+    expect(() => validateSessionInput(baseInput({ durationMinutes: 30.5 }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects non-number', () => {
+    expect(() =>
+      validateSessionInput(baseInput({ durationMinutes: '30' as unknown as number })),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateSessionInput — notes', () => {
+  it('normalizes missing notes to null', () => {
+    expect(validateSessionInput(baseInput()).notes).toBeNull();
+  });
+
+  it('normalizes empty string to null', () => {
+    expect(validateSessionInput(baseInput({ notes: '' })).notes).toBeNull();
+  });
+
+  it('normalizes whitespace-only to null', () => {
+    expect(validateSessionInput(baseInput({ notes: '   ' })).notes).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(validateSessionInput(baseInput({ notes: '  foo  ' })).notes).toBe('foo');
+  });
+
+  it('accepts the upper-bound length (2000)', () => {
+    const result = validateSessionInput(baseInput({ notes: 'x'.repeat(2000) }));
+    expect(result.notes).toHaveLength(2000);
+  });
+
+  it('rejects > 2000 chars', () => {
+    expect(() => validateSessionInput(baseInput({ notes: 'x'.repeat(2001) }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects non-string notes', () => {
+    expect(() =>
+      validateSessionInput(baseInput({ notes: 123 as unknown as string })),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateSessionInput — practiceGridId', () => {
+  it('defaults to null when absent', () => {
+    expect(validateSessionInput(baseInput()).practiceGridId).toBeNull();
+  });
+
+  it('normalizes explicit null to null', () => {
+    expect(validateSessionInput(baseInput({ practiceGridId: null })).practiceGridId).toBeNull();
+  });
+
+  it('accepts a valid UUID', () => {
+    const uuid = '00000000-0000-0000-0000-000000000001';
+    expect(validateSessionInput(baseInput({ practiceGridId: uuid })).practiceGridId).toBe(uuid);
+  });
+
+  it('rejects a malformed UUID', () => {
+    expect(() => validateSessionInput(baseInput({ practiceGridId: 'not-a-uuid' }))).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('rejects a non-string practiceGridId', () => {
+    expect(() =>
+      validateSessionInput(baseInput({ practiceGridId: 42 as unknown as string })),
+    ).toThrow(ValidationError);
+  });
+});

--- a/tests/unit/models/template.test.ts
+++ b/tests/unit/models/template.test.ts
@@ -136,4 +136,16 @@ describe('validateGridData — passageLabel', () => {
       }),
     ).toThrow(ValidationError);
   });
+
+  it('rejects non-object rows (null entry)', () => {
+    expect(() =>
+      validateGridData({ rows: [null] } as unknown),
+    ).toThrow(/must be an object/);
+  });
+
+  it('rejects non-object rows (string entry)', () => {
+    expect(() =>
+      validateGridData({ rows: ['not an object'] } as unknown),
+    ).toThrow(/must be an object/);
+  });
 });

--- a/tests/unit/models/template.test.ts
+++ b/tests/unit/models/template.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { validateGridData, type TemplateGridData } from '@/models/template';
+import { ValidationError } from '@/lib/errors';
+
+function baseGridData(overrides: Partial<TemplateGridData> = {}): TemplateGridData {
+  return {
+    rows: [
+      { passageLabel: 'Study #1', startMeasure: 1, endMeasure: 16, targetTempo: 120, steps: 5 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validateGridData — structure', () => {
+  it('accepts a valid blob with one row', () => {
+    const result = validateGridData(baseGridData());
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it('accepts multiple rows', () => {
+    const result = validateGridData({
+      rows: [
+        { startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 3 },
+        { startMeasure: 5, endMeasure: 8, targetTempo: 120, steps: 4 },
+      ],
+    });
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it('rejects null', () => {
+    expect(() => validateGridData(null)).toThrow(ValidationError);
+  });
+
+  it('rejects a plain string', () => {
+    expect(() => validateGridData('{"rows":[]}' as unknown)).toThrow(ValidationError);
+  });
+
+  it('rejects missing rows field', () => {
+    expect(() => validateGridData({} as unknown)).toThrow(ValidationError);
+  });
+
+  it('rejects rows as non-array', () => {
+    expect(() => validateGridData({ rows: 'not-an-array' } as unknown)).toThrow(ValidationError);
+  });
+
+  it('rejects empty rows array', () => {
+    expect(() => validateGridData({ rows: [] })).toThrow(ValidationError);
+  });
+});
+
+describe('validateGridData — row-level bounds', () => {
+  it('rejects startMeasure < 1', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 0, endMeasure: 4, targetTempo: 100, steps: 3 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects startMeasure > 99999', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 100000, endMeasure: 100001, targetTempo: 100, steps: 3 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects endMeasure < startMeasure', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 10, endMeasure: 5, targetTempo: 100, steps: 3 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects targetTempo > 999', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 1, endMeasure: 4, targetTempo: 1000, steps: 3 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects steps > 50', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 51 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects steps < 1', () => {
+    expect(() =>
+      validateGridData({
+        rows: [{ startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 0 }],
+      }),
+    ).toThrow(ValidationError);
+  });
+});
+
+describe('validateGridData — passageLabel', () => {
+  it('accepts a row without passageLabel', () => {
+    const result = validateGridData({
+      rows: [{ startMeasure: 1, endMeasure: 4, targetTempo: 100, steps: 3 }],
+    });
+    expect(result.rows[0].passageLabel).toBeNull();
+  });
+
+  it('accepts a row with passageLabel', () => {
+    const result = validateGridData({
+      rows: [
+        {
+          passageLabel: 'Letter A',
+          startMeasure: 1,
+          endMeasure: 4,
+          targetTempo: 100,
+          steps: 3,
+        },
+      ],
+    });
+    expect(result.rows[0].passageLabel).toBe('Letter A');
+  });
+
+  it('rejects passageLabel > 200 chars', () => {
+    expect(() =>
+      validateGridData({
+        rows: [
+          {
+            passageLabel: 'x'.repeat(201),
+            startMeasure: 1,
+            endMeasure: 4,
+            targetTempo: 100,
+            steps: 3,
+          },
+        ],
+      }),
+    ).toThrow(ValidationError);
+  });
+});

--- a/tests/unit/routes/api-routes.test.ts
+++ b/tests/unit/routes/api-routes.test.ts
@@ -15,7 +15,29 @@ vi.mock('@/controllers/grid', () => ({
   listGrids: vi.fn(() => NextResponse.json({ mock: 'listGrids' })),
   getGrid: vi.fn(() => NextResponse.json({ mock: 'getGrid' })),
   deleteGrid: vi.fn(() => new NextResponse(null, { status: 204 })),
+  updateGrid: vi.fn(() => NextResponse.json({ mock: 'updateGrid' })),
   updateFade: vi.fn(() => NextResponse.json({ mock: 'updateFade' })),
+}));
+
+vi.mock('@/controllers/session', () => ({
+  createSession: vi.fn(() => NextResponse.json({ mock: 'createSession' }, { status: 201 })),
+  listSessions: vi.fn(() => NextResponse.json({ mock: 'listSessions' })),
+  getSession: vi.fn(() => NextResponse.json({ mock: 'getSession' })),
+  deleteSession: vi.fn(() => new NextResponse(null, { status: 204 })),
+}));
+
+vi.mock('@/controllers/goal', () => ({
+  createGoal: vi.fn(() => NextResponse.json({ mock: 'createGoal' }, { status: 201 })),
+  listGoals: vi.fn(() => NextResponse.json({ mock: 'listGoals' })),
+  getGoal: vi.fn(() => NextResponse.json({ mock: 'getGoal' })),
+  updateGoal: vi.fn(() => NextResponse.json({ mock: 'updateGoal' })),
+  deleteGoal: vi.fn(() => new NextResponse(null, { status: 204 })),
+}));
+
+vi.mock('@/controllers/template', () => ({
+  listTemplates: vi.fn(() => NextResponse.json({ mock: 'listTemplates' })),
+  getTemplate: vi.fn(() => NextResponse.json({ mock: 'getTemplate' })),
+  cloneTemplate: vi.fn(() => NextResponse.json({ mock: 'cloneTemplate' }, { status: 201 })),
 }));
 
 vi.mock('@/controllers/cell', () => ({
@@ -86,6 +108,16 @@ describe('Grid routes — /api/grids/[id]', () => {
     expect(getGrid).toHaveBeenCalledWith('test-grid-id');
   });
 
+  it('PUT extracts id and delegates to updateGrid', async () => {
+    const { PUT } = await import('@/app/api/grids/[id]/route');
+    const { updateGrid } = await import('@/controllers/grid');
+    const req = makeRequest('PUT');
+    const params = makeParams({ id: 'test-grid-id' });
+
+    await PUT(req, params);
+    expect(updateGrid).toHaveBeenCalledWith('test-grid-id', req);
+  });
+
   it('DELETE extracts id and delegates to deleteGrid', async () => {
     const { DELETE } = await import('@/app/api/grids/[id]/route');
     const { deleteGrid } = await import('@/controllers/grid');
@@ -94,6 +126,129 @@ describe('Grid routes — /api/grids/[id]', () => {
 
     await DELETE(req, params);
     expect(deleteGrid).toHaveBeenCalledWith('test-grid-id');
+  });
+});
+
+// ─── Session routes ──────────────────────────────────────────────────────────
+
+describe('Session routes — /api/sessions', () => {
+  it('POST delegates to createSession', async () => {
+    const { POST } = await import('@/app/api/sessions/route');
+    const { createSession } = await import('@/controllers/session');
+    const req = makeRequest('POST');
+    await POST(req);
+    expect(createSession).toHaveBeenCalledWith(req);
+  });
+
+  it('GET delegates to listSessions', async () => {
+    const { GET } = await import('@/app/api/sessions/route');
+    const { listSessions } = await import('@/controllers/session');
+    const req = makeRequest('GET');
+    await GET(req);
+    expect(listSessions).toHaveBeenCalledWith(req);
+  });
+});
+
+describe('Session routes — /api/sessions/[id]', () => {
+  it('GET extracts id and delegates to getSession', async () => {
+    const { GET } = await import('@/app/api/sessions/[id]/route');
+    const { getSession } = await import('@/controllers/session');
+    const req = makeRequest();
+    const params = makeParams({ id: 'session-1' });
+    await GET(req, params);
+    expect(getSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('DELETE extracts id and delegates to deleteSession', async () => {
+    const { DELETE } = await import('@/app/api/sessions/[id]/route');
+    const { deleteSession } = await import('@/controllers/session');
+    const req = makeRequest('DELETE');
+    const params = makeParams({ id: 'session-1' });
+    await DELETE(req, params);
+    expect(deleteSession).toHaveBeenCalledWith('session-1');
+  });
+});
+
+// ─── Goal routes ─────────────────────────────────────────────────────────────
+
+describe('Goal routes — /api/goals', () => {
+  it('POST delegates to createGoal', async () => {
+    const { POST } = await import('@/app/api/goals/route');
+    const { createGoal } = await import('@/controllers/goal');
+    const req = makeRequest('POST');
+    await POST(req);
+    expect(createGoal).toHaveBeenCalledWith(req);
+  });
+
+  it('GET delegates to listGoals', async () => {
+    const { GET } = await import('@/app/api/goals/route');
+    const { listGoals } = await import('@/controllers/goal');
+    const req = makeRequest('GET');
+    await GET(req);
+    expect(listGoals).toHaveBeenCalledWith(req);
+  });
+});
+
+describe('Goal routes — /api/goals/[id]', () => {
+  it('GET extracts id and delegates to getGoal', async () => {
+    const { GET } = await import('@/app/api/goals/[id]/route');
+    const { getGoal } = await import('@/controllers/goal');
+    const req = makeRequest();
+    const params = makeParams({ id: 'goal-1' });
+    await GET(req, params);
+    expect(getGoal).toHaveBeenCalledWith('goal-1');
+  });
+
+  it('PUT extracts id and delegates to updateGoal', async () => {
+    const { PUT } = await import('@/app/api/goals/[id]/route');
+    const { updateGoal } = await import('@/controllers/goal');
+    const req = makeRequest('PUT');
+    const params = makeParams({ id: 'goal-1' });
+    await PUT(req, params);
+    expect(updateGoal).toHaveBeenCalledWith('goal-1', req);
+  });
+
+  it('DELETE extracts id and delegates to deleteGoal', async () => {
+    const { DELETE } = await import('@/app/api/goals/[id]/route');
+    const { deleteGoal } = await import('@/controllers/goal');
+    const req = makeRequest('DELETE');
+    const params = makeParams({ id: 'goal-1' });
+    await DELETE(req, params);
+    expect(deleteGoal).toHaveBeenCalledWith('goal-1');
+  });
+});
+
+// ─── Template routes ─────────────────────────────────────────────────────────
+
+describe('Template routes — /api/templates', () => {
+  it('GET delegates to listTemplates', async () => {
+    const { GET } = await import('@/app/api/templates/route');
+    const { listTemplates } = await import('@/controllers/template');
+    const req = makeRequest('GET');
+    await GET(req);
+    expect(listTemplates).toHaveBeenCalledWith(req);
+  });
+});
+
+describe('Template routes — /api/templates/[id]', () => {
+  it('GET extracts id and delegates to getTemplate', async () => {
+    const { GET } = await import('@/app/api/templates/[id]/route');
+    const { getTemplate } = await import('@/controllers/template');
+    const req = makeRequest();
+    const params = makeParams({ id: 'template-1' });
+    await GET(req, params);
+    expect(getTemplate).toHaveBeenCalledWith('template-1');
+  });
+});
+
+describe('Template routes — /api/templates/[id]/clone', () => {
+  it('POST extracts id and delegates to cloneTemplate', async () => {
+    const { POST } = await import('@/app/api/templates/[id]/clone/route');
+    const { cloneTemplate } = await import('@/controllers/template');
+    const req = makeRequest('POST');
+    const params = makeParams({ id: 'template-1' });
+    await POST(req, params);
+    expect(cloneTemplate).toHaveBeenCalledWith('template-1');
   });
 });
 

--- a/tests/unit/views/goal.test.ts
+++ b/tests/unit/views/goal.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { formatGoal, formatGoalList } from '@/views/goal';
+
+const baseRecord = {
+  id: '00000000-0000-0000-0000-000000000001',
+  userId: '00000000-0000-0000-0000-000000000099',
+  goalType: 'DAILY_MINUTES' as const,
+  targetValue: 30,
+  active: true,
+  createdAt: new Date('2026-04-01T12:00:00.000Z'),
+  updatedAt: new Date('2026-04-02T12:00:00.000Z'),
+  deletedAt: null,
+};
+
+describe('formatGoal', () => {
+  it('returns public fields and strips userId + deletedAt', () => {
+    const result = formatGoal(baseRecord);
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('goalType');
+    expect(result).toHaveProperty('targetValue');
+    expect(result).toHaveProperty('active');
+    expect(result).toHaveProperty('createdAt');
+    expect(result).toHaveProperty('updatedAt');
+    expect(result).not.toHaveProperty('userId');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('renders timestamps as ISO 8601', () => {
+    const result = formatGoal(baseRecord);
+    expect(result.createdAt).toBe('2026-04-01T12:00:00.000Z');
+    expect(result.updatedAt).toBe('2026-04-02T12:00:00.000Z');
+  });
+
+  it('preserves active flag', () => {
+    expect(formatGoal({ ...baseRecord, active: false }).active).toBe(false);
+  });
+
+  it('preserves goalType enum value', () => {
+    const weekly = formatGoal({ ...baseRecord, goalType: 'WEEKLY_MINUTES' });
+    expect(weekly.goalType).toBe('WEEKLY_MINUTES');
+  });
+});
+
+describe('formatGoalList', () => {
+  it('maps over an array', () => {
+    const list = formatGoalList([
+      baseRecord,
+      { ...baseRecord, id: '00000000-0000-0000-0000-000000000002' },
+    ]);
+    expect(list).toHaveLength(2);
+    expect(list[0]).not.toHaveProperty('userId');
+  });
+
+  it('handles empty input', () => {
+    expect(formatGoalList([])).toEqual([]);
+  });
+});

--- a/tests/unit/views/grid.test.ts
+++ b/tests/unit/views/grid.test.ts
@@ -7,6 +7,9 @@ const mockGrid = {
   name: 'Test Grid',
   notes: 'Some notes',
   fadeEnabled: true,
+  gridType: 'REPERTOIRE',
+  archived: false,
+  sourceTemplateId: null,
   createdAt: new Date('2026-03-15T10:00:00Z'),
   updatedAt: new Date('2026-03-15T12:00:00Z'),
   deletedAt: null,
@@ -78,6 +81,13 @@ describe('Grid view — formatGrid', () => {
     expect(result).toHaveProperty('updatedAt');
     expect(result).not.toHaveProperty('userId');
     expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('includes gridType, archived, sourceTemplateId (M2.1)', () => {
+    const result = formatGrid(mockGrid);
+    expect(result.gridType).toBe('REPERTOIRE');
+    expect(result.archived).toBe(false);
+    expect(result.sourceTemplateId).toBeNull();
   });
 });
 

--- a/tests/unit/views/session.test.ts
+++ b/tests/unit/views/session.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { formatSession, formatSessionList } from '@/views/session';
+
+const baseRecord = {
+  id: '00000000-0000-0000-0000-000000000001',
+  userId: '00000000-0000-0000-0000-000000000099',
+  practiceGridId: '00000000-0000-0000-0000-000000000010',
+  sessionDate: new Date('2026-04-01T00:00:00.000Z'),
+  durationMinutes: 30,
+  notes: 'Practiced scales',
+  source: 'MANUAL' as const,
+  createdAt: new Date('2026-04-01T18:30:00.000Z'),
+  deletedAt: null,
+};
+
+describe('formatSession', () => {
+  it('returns public fields only — strips userId and deletedAt', () => {
+    const result = formatSession(baseRecord);
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('practiceGridId');
+    expect(result).toHaveProperty('sessionDate');
+    expect(result).toHaveProperty('durationMinutes');
+    expect(result).toHaveProperty('notes');
+    expect(result).toHaveProperty('source');
+    expect(result).toHaveProperty('createdAt');
+    expect(result).not.toHaveProperty('userId');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('renders sessionDate as a YYYY-MM-DD string (no time component)', () => {
+    const result = formatSession(baseRecord);
+    expect(result.sessionDate).toBe('2026-04-01');
+    expect(result.sessionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('renders createdAt as ISO 8601', () => {
+    const result = formatSession(baseRecord);
+    expect(result.createdAt).toBe('2026-04-01T18:30:00.000Z');
+  });
+
+  it('preserves null practiceGridId', () => {
+    const result = formatSession({ ...baseRecord, practiceGridId: null });
+    expect(result.practiceGridId).toBeNull();
+  });
+
+  it('preserves null notes', () => {
+    const result = formatSession({ ...baseRecord, notes: null });
+    expect(result.notes).toBeNull();
+  });
+
+  it('preserves source field', () => {
+    const inferred = formatSession({ ...baseRecord, source: 'INFERRED' });
+    expect(inferred.source).toBe('INFERRED');
+  });
+});
+
+describe('formatSessionList', () => {
+  it('maps over an array of records', () => {
+    const list = formatSessionList([
+      baseRecord,
+      { ...baseRecord, id: '00000000-0000-0000-0000-000000000002' },
+    ]);
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe('00000000-0000-0000-0000-000000000001');
+    expect(list[1].id).toBe('00000000-0000-0000-0000-000000000002');
+    expect(list[0]).not.toHaveProperty('userId');
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(formatSessionList([])).toEqual([]);
+  });
+});

--- a/tests/unit/views/template.test.ts
+++ b/tests/unit/views/template.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { formatTemplate, formatTemplateDetail, formatTemplateList } from '@/views/template';
+
+const baseRecord = {
+  id: '00000000-0000-0000-0000-000000000001',
+  title: 'Clarke Technical Studies',
+  author: 'Herbert L. Clarke',
+  collection: 'Technical Studies for the Cornet',
+  description: 'A collection of technical studies',
+  instrumentTags: ['trumpet', 'cornet'],
+  gridType: 'REPERTOIRE' as const,
+  tierRequired: 'FREE' as const,
+  gridData: {
+    rows: [
+      { passageLabel: 'Study #1', startMeasure: 1, endMeasure: 16, targetTempo: 120, steps: 5 },
+    ],
+  },
+  active: true,
+  createdAt: new Date('2026-04-01T12:00:00.000Z'),
+  updatedAt: new Date('2026-04-02T12:00:00.000Z'),
+  deletedAt: null,
+};
+
+describe('formatTemplate', () => {
+  it('returns list-view fields and omits gridData, deletedAt', () => {
+    const result = formatTemplate(baseRecord);
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('title');
+    expect(result).toHaveProperty('author');
+    expect(result).toHaveProperty('collection');
+    expect(result).toHaveProperty('description');
+    expect(result).toHaveProperty('instrumentTags');
+    expect(result).toHaveProperty('gridType');
+    expect(result).toHaveProperty('tierRequired');
+    expect(result).toHaveProperty('active');
+    expect(result).toHaveProperty('createdAt');
+    expect(result).toHaveProperty('updatedAt');
+    expect(result).not.toHaveProperty('gridData');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('renders timestamps as ISO 8601', () => {
+    const result = formatTemplate(baseRecord);
+    expect(result.createdAt).toBe('2026-04-01T12:00:00.000Z');
+    expect(result.updatedAt).toBe('2026-04-02T12:00:00.000Z');
+  });
+});
+
+describe('formatTemplateDetail', () => {
+  it('includes all list-view fields plus gridData', () => {
+    const result = formatTemplateDetail(baseRecord);
+    expect(result).toHaveProperty('gridData');
+    expect(result.gridData).toEqual(baseRecord.gridData);
+    expect(result).toHaveProperty('title');
+    expect(result).toHaveProperty('instrumentTags');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+});
+
+describe('formatTemplateList', () => {
+  it('maps and strips gridData', () => {
+    const list = formatTemplateList([
+      baseRecord,
+      { ...baseRecord, id: '00000000-0000-0000-0000-000000000002' },
+    ]);
+    expect(list).toHaveLength(2);
+    expect(list[0]).not.toHaveProperty('gridData');
+    expect(list[1]).not.toHaveProperty('gridData');
+  });
+});


### PR DESCRIPTION
## Summary

M2.1 delivers the V2 domain model groundwork: **3 new entities** (PracticeSession, PracticeGoal, LibraryTemplate), **3 new fields on PracticeGrid** (gridType, archived, sourceTemplateId), and **full CRUD API** for all new entities following the established MCV pattern. Template cloning is fully transactional.

Scope per `docs/specs/2026-03-22-m2.1-domain-model-v2-design.md` and `docs/plans/2026-03-24-m2.1-domain-model-v2.md`.

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `b3e771e` | **Schema migration** — 4 enums, 3 PracticeGrid fields, 3 new models, indexes, SOFT_DELETE_MODELS allowlist update. Fully additive. |
| 2 | `06582ff` | **Grid update endpoint** — PUT /api/grids/{id}, ?archived filter, formatGrid fields (gridType/archived/sourceTemplateId), updateGridFade now thin wrapper |
| 3 | `4f7a0e1` | **PracticeSession model** — strict YYYY-MM-DD date validation, duration bounds, grid ownership check, soft-delete |
| 4 | `44cd73b` | **PracticeSession view/controller/routes** — POST/GET/GET-by-id/DELETE with ?from & ?to date range |
| 5 | `939e1b3` | **PracticeGoal model** — goalType enum, 1-10000 target bounds, goalType immutability on update, one-active-per-type ConflictError |
| 6 | `a44c043` | **PracticeGoal view/controller/routes** — POST/GET/GET-by-id/PUT/DELETE with ?all active filter |
| 7 | `aa8a910` | **LibraryTemplate model + gridData validation** — reuses validateRowInput for row-level bounds, case-insensitive instrument filter |
| 8 | `174c459` | **Template clone + view/controller/routes** — transactional clone via prisma.$transaction, returns formatGridDetail on 201 |
| 9 | `c24a7f3` | **Seed + coverage top-up** — Clarke template fixture, route-level tests, 500-path tests, type-check tests |

## Acceptance criteria

UC-2.1 Multiple Grids (archived filter):
- [x] ?archived=false (default) returns active only — `tests/integration/api/grids.test.ts` `GET /api/grids excludes archived by default`
- [x] ?archived=true returns archived only
- [x] ?archived=all returns both
- [x] ?detail=true composes with ?archived — `GET /api/grids?detail=true&archived=true composes both filters`
- [x] Direct GET /api/grids/{id} still returns archived grids
- [x] Archiving is purely a list filter (no behavior change)

UC-2.2 Practice Time (session model):
- [x] PracticeSession schema with sessionDate/durationMinutes/source — `b3e771e`
- [x] Calendar-date semantics (YYYY-MM-DD string, no tz conversion) — `validateSessionInput` tests
- [x] Manual entries only in M2.1 (source always MANUAL) — `createSession` model
- [x] Optional grid link with ownership check — `POST with practiceGridId for other user returns 400`
- [x] Date-range filter inclusive — `GET ?from= filter is inclusive`, `GET ?to= filter is inclusive`
- [x] Sessions are immutable (no PUT endpoint)

UC-2.5 Goal Setting (goal model):
- [x] PracticeGoal schema — `b3e771e`
- [x] 4 goalType values — `goal.test.ts`
- [x] One active goal per goalType (409 ConflictError) — `POST duplicate active goalType returns 409`
- [x] goalType immutable after create — `PUT rejects goalType in body (400)`
- [x] Default active-only filter + ?all=true — `goal list tests`

UC-2.7 Technique Grid (gridType enum):
- [x] GridType enum REPERTOIRE/TECHNIQUE — schema
- [x] PracticeGrid.gridType field with REPERTOIRE default — schema
- [x] PUT can change gridType — `PUT updates gridType to TECHNIQUE`

UC-2.8 Library (template model + clone):
- [x] LibraryTemplate schema with gridData JSON — `b3e771e`
- [x] List with optional instrument filter — `GET ?instrument=trumpet filters (case-insensitive substring)`
- [x] Detail with gridData — `GET /{id} returns template with gridData`
- [x] Transactional clone creating grid + rows + cells — `POST /{id}/clone creates a grid with rows and cells`
- [x] Clone rolls back on validation failure — `POST /{id}/clone is transactional — no partial grid on validation failure`
- [x] Clone carries template.gridType through to the new grid
- [x] Clone returns formatGridDetail(201) so client can immediately render

## Rejection criteria

- [x] **No destructive migration** — migration is 100% additive (4 enums CREATE, 3 columns ADD with defaults, 3 tables CREATE, 4 indexes, 4 FK constraints). Auto-generated SQL verified; no hand-edit needed.
- [x] **No new API versions** — single-version API, endpoints only added
- [x] **No existing data modified** — all schema changes are additive; existing rows get defaults for new columns
- [x] **No hard deletes** — new models join SOFT_DELETE_MODELS and use the extension's delete interceptor
- [x] **No new npm deps** — pure schema + application code
- [x] **Coverage ≥ 95%** — 97.5 stmts / 95.94 branches / 96.69 funcs / 98.47 lines
- [x] **TDD throughout** — every task wrote tests first and watched them fail before implementing (see commit diffs)

## Test plan

- [x] Unit: model validation (sessionDate format + bounds, goalType enum, gridData structure + row bounds)
- [x] Unit: view formatting (field stripping, YYYY-MM-DD serialization, ISO timestamp serialization)
- [x] Unit: route delegation (mocked controllers, param extraction, response passthrough)
- [x] Unit: 500-path error handling (all new controller actions)
- [x] Integration: full CRUD for sessions, goals, templates
- [x] Integration: clone creates grid + rows + cells transactionally
- [x] Integration: archived filter on list + compose with detail
- [x] Integration: grid PUT (all field combinations + error paths)
- [x] `npm run verify` green — lint, typecheck, coverage, build

## Schema migration

Single additive migration in `prisma/migrations/20260411050344_v2_domain_model/migration.sql`. Verified locally against both dev and test databases. Production deploy will apply via `prisma migrate deploy` in the standard CI/CD path — no special steps required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)